### PR TITLE
[FEAT] 커스텀 전역 예외처리

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,9 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 
+	//객체 검증
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
+
 	// jwt
 	implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.5'
 	implementation group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.5'

--- a/src/main/java/com/triprecord/triprecord/global/config/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/triprecord/triprecord/global/config/jwt/JwtAuthenticationFilter.java
@@ -37,12 +37,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
                 SecurityContextHolder.getContext().setAuthentication(authentication);
             }
-        } catch (Exception exception) {
-            try {
-                throw new Exception();
-            } catch (Exception e) {
-                throw new RuntimeException(e);
-            }
+        } catch (RuntimeException e) {
+            throw new RuntimeException();
         }
         // 다음 필터로 요청 전달
         filterChain.doFilter(request, response);

--- a/src/main/java/com/triprecord/triprecord/global/exception/ErrorCode.java
+++ b/src/main/java/com/triprecord/triprecord/global/exception/ErrorCode.java
@@ -1,8 +1,6 @@
 package com.triprecord.triprecord.global.exception;
 
 
-
-
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.springframework.http.HttpStatus;

--- a/src/main/java/com/triprecord/triprecord/global/exception/ErrorCode.java
+++ b/src/main/java/com/triprecord/triprecord/global/exception/ErrorCode.java
@@ -1,0 +1,20 @@
+package com.triprecord.triprecord.global.exception;
+
+
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorCode {
+
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND,"유저 정보를 찾을 수 없습니다."),
+    DUPLICATE_EMAIL(HttpStatus.CONFLICT, "이미 존재하는 이메일입니다."),
+    INVALID_PASSWORD(HttpStatus.UNAUTHORIZED,"비밀번호가 일치하지 않습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+}

--- a/src/main/java/com/triprecord/triprecord/global/exception/GlobalControllerAdvice.java
+++ b/src/main/java/com/triprecord/triprecord/global/exception/GlobalControllerAdvice.java
@@ -22,7 +22,7 @@ public class GlobalControllerAdvice {
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ExceptionDTO> methodArgumentNotValidException(final MethodArgumentNotValidException e){
         log.error(String.format(ERROR_LOG, e.getParameter(), "객체검증에러"));
-        return ResponseEntity.ok(new ExceptionDTO("필요한 데이터가 모두 입력되지 않았습니다."));
+        return ResponseEntity.badRequest().body(new ExceptionDTO("필요한 데이터가 모두 입력되지 않았습니다."));
     }
 
     @ExceptionHandler(RuntimeException.class)

--- a/src/main/java/com/triprecord/triprecord/global/exception/GlobalControllerAdvice.java
+++ b/src/main/java/com/triprecord/triprecord/global/exception/GlobalControllerAdvice.java
@@ -1,0 +1,24 @@
+package com.triprecord.triprecord.global.exception;
+
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalControllerAdvice {
+
+    private final String ERROR_LOG = "[ERROR] %s %s";
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ExceptionDTO> methodArgumentNotValidException(final MethodArgumentNotValidException e){
+        log.error(String.format(ERROR_LOG, e.getParameter(), "객체검증에러"));
+        return ResponseEntity.ok(new ExceptionDTO("필요한 데이터가 모두 입력되지 않았습니다."));
+    }
+
+    record ExceptionDTO(String message){
+    }
+}

--- a/src/main/java/com/triprecord/triprecord/global/exception/GlobalControllerAdvice.java
+++ b/src/main/java/com/triprecord/triprecord/global/exception/GlobalControllerAdvice.java
@@ -28,7 +28,7 @@ public class GlobalControllerAdvice {
     @ExceptionHandler(RuntimeException.class)
     public ResponseEntity<ExceptionDTO> unexpectedRuntimeException(final RuntimeException e){
         log.error(String.format(ERROR_LOG, e.getClass().getSimpleName(), e.getMessage()));
-        return ResponseEntity.badRequest().body(new ExceptionDTO("unexpected runtime exception"));
+        return ResponseEntity.badRequest().body(new ExceptionDTO("예기치 않은 런타임 에러입니다."));
     }
 
     record ExceptionDTO(String message){

--- a/src/main/java/com/triprecord/triprecord/global/exception/GlobalControllerAdvice.java
+++ b/src/main/java/com/triprecord/triprecord/global/exception/GlobalControllerAdvice.java
@@ -13,6 +13,12 @@ public class GlobalControllerAdvice {
 
     private final String ERROR_LOG = "[ERROR] %s %s";
 
+    @ExceptionHandler(TripRecordException.class)
+    public ResponseEntity<ExceptionDTO> applicationException(final TripRecordException e){
+        log.error(String.format(ERROR_LOG, e.getHttpStatus(), e.getMessage()));
+        return ResponseEntity.status(e.getHttpStatus()).body(new ExceptionDTO(e.getMessage()));
+    }
+
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ExceptionDTO> methodArgumentNotValidException(final MethodArgumentNotValidException e){
         log.error(String.format(ERROR_LOG, e.getParameter(), "객체검증에러"));

--- a/src/main/java/com/triprecord/triprecord/global/exception/GlobalControllerAdvice.java
+++ b/src/main/java/com/triprecord/triprecord/global/exception/GlobalControllerAdvice.java
@@ -25,6 +25,12 @@ public class GlobalControllerAdvice {
         return ResponseEntity.ok(new ExceptionDTO("필요한 데이터가 모두 입력되지 않았습니다."));
     }
 
+    @ExceptionHandler(RuntimeException.class)
+    public ResponseEntity<ExceptionDTO> unexpectedRuntimeException(final RuntimeException e){
+        log.error(String.format(ERROR_LOG, e.getClass().getSimpleName(), e.getMessage()));
+        return ResponseEntity.badRequest().body(new ExceptionDTO("unexpected runtime exception"));
+    }
+
     record ExceptionDTO(String message){
     }
 }

--- a/src/main/java/com/triprecord/triprecord/global/exception/TripRecordException.java
+++ b/src/main/java/com/triprecord/triprecord/global/exception/TripRecordException.java
@@ -1,0 +1,25 @@
+package com.triprecord.triprecord.global.exception;
+
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class TripRecordException extends RuntimeException {
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    @Override
+    public String getMessage(){
+        return message;
+    }
+
+    public TripRecordException(ErrorCode errorCode){
+        this.httpStatus = errorCode.getHttpStatus();
+        this.message = errorCode.getMessage();
+    }
+
+}

--- a/src/main/java/com/triprecord/triprecord/user/UserController.java
+++ b/src/main/java/com/triprecord/triprecord/user/UserController.java
@@ -26,7 +26,7 @@ public class UserController {
     }
 
     @PostMapping("/login")
-    public ResponseEntity<?> login(@RequestBody @Valid UserLoginRequest userLoginRequest) {
+    public ResponseEntity<Map<String, String>> login(@RequestBody @Valid UserLoginRequest userLoginRequest) {
         String token = userService.login(userLoginRequest);
         return ResponseEntity.ok().body(Map.of("Authorization", token));
     }

--- a/src/main/java/com/triprecord/triprecord/user/UserController.java
+++ b/src/main/java/com/triprecord/triprecord/user/UserController.java
@@ -1,6 +1,7 @@
 package com.triprecord.triprecord.user;
 
 import jakarta.security.auth.message.AuthException;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -19,22 +20,14 @@ public class UserController {
     private final UserService userService;
 
     @PostMapping("/signup")
-    public ResponseEntity<String> signup(@RequestBody UserCreateRequest userCreateRequest) {
-        try {
-            URI uri = URI.create("/users/" + userService.signup(userCreateRequest));
-            return ResponseEntity.created(uri).build();
-        } catch (IllegalArgumentException e) {
-            return ResponseEntity.badRequest().body(e.getMessage());
-        }
+    public ResponseEntity<String> signup(@RequestBody @Valid UserCreateRequest userCreateRequest) {
+        URI uri = URI.create("/users/" + userService.signup(userCreateRequest));
+        return ResponseEntity.created(uri).build();
     }
 
     @PostMapping("/login")
-    public ResponseEntity<?> login(@RequestBody UserLoginRequest userLoginRequest) {
-        try {
-            String token = userService.login(userLoginRequest);
-            return ResponseEntity.ok().body(Map.of("Authorization", token));
-        } catch (AuthException e) {
-            return ResponseEntity.badRequest().body(e.getMessage());
-        }
+    public ResponseEntity<?> login(@RequestBody @Valid UserLoginRequest userLoginRequest) {
+        String token = userService.login(userLoginRequest);
+        return ResponseEntity.ok().body(Map.of("Authorization", token));
     }
 }

--- a/src/main/java/com/triprecord/triprecord/user/UserCreateRequest.java
+++ b/src/main/java/com/triprecord/triprecord/user/UserCreateRequest.java
@@ -1,13 +1,14 @@
 package com.triprecord.triprecord.user;
 
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotNull;
 import java.time.LocalDate;
-
 public record UserCreateRequest(
-        String userEmail,
-        String userPassword,
-        String userNickname,
-        LocalDate userAge,
-        Long userBasicProfileId,
-        Long userTripStyleId
+        @Email String userEmail,
+        @NotNull String userPassword,
+        @NotNull String userNickname,
+        @NotNull LocalDate userAge,
+        @NotNull Long userBasicProfileId,
+        @NotNull Long userTripStyleId
 ) {
 }

--- a/src/main/java/com/triprecord/triprecord/user/UserCreateRequest.java
+++ b/src/main/java/com/triprecord/triprecord/user/UserCreateRequest.java
@@ -4,7 +4,7 @@ import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDate;
 public record UserCreateRequest(
-        @Email String userEmail,
+        @Email @NotNull String userEmail,
         @NotNull String userPassword,
         @NotNull String userNickname,
         @NotNull LocalDate userAge,

--- a/src/main/java/com/triprecord/triprecord/user/UserLoginRequest.java
+++ b/src/main/java/com/triprecord/triprecord/user/UserLoginRequest.java
@@ -1,7 +1,9 @@
 package com.triprecord.triprecord.user;
 
+import jakarta.validation.constraints.NotNull;
+
 public record UserLoginRequest(
-        String userEmail,
-        String userPassword
+        @NotNull String userEmail,
+        @NotNull String userPassword
 ) {
 }


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- feat/#6 -> dev
- close #6

## Key Changes
<!-- 최대한 자세히 -->
- 예외 발생시의 return 값을 커스텀했습니다.
예외를 발생시킬 상황에 커스텀 오류를 알맞은 ErrorCode와 함께 던집니다.
```java
if (user.isPresent()) {
        throw new TripRecordException(ErrorCode.DUPLICATE_EMAIL);
}
```
![image](https://github.com/Trip-Record/Server/assets/105481797/178a99ee-b2b2-4ba4-93a4-5048bddbdd8f)


- request 객체가 검증되도록 했습니다.
필수 데이터가 모두 입력되지 않았을 경우, 다음과 같은 결과가 반환됩니다.
![image](https://github.com/Trip-Record/Server/assets/105481797/07b4a4be-4c54-4d8b-9f78-e8fcf2f38bf8)




## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->
- dto class에서는 `@NotNull` , controller class 에는 `@Valid`를 사용하면 데이터가 들어오지 않은 경우 예외를 발생시킵니다.
- 예외를 발생시킬 때에는 TripRecordException을 던지고 인자로 ErrorCode를 전달하면 됩니다.
- ErrorCode enum 클래스에는 return 되는 httpStatus가 정의됩니다.
필요한 상황이 있을 때마다 각자 에러코드를 정의해서 활용하면 됩니다.
ex) `RECORD_NOT_FOUND(HttpStatus.NOT_FOUND,"기록 정보를 찾을 수 없습니다.")`

앞으로 구현할 때 해당 내용을 활용해 개발을 진행하면 될 것 같습니다! 😃
개선할 점, 궁금한 점 등 편하게 말해주세요 ~ !
