### PR TITLE
[FEAT] S3 파일 업로드 서비스

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,9 @@ dependencies {
 	implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.5'
 	implementation group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.5'
 	implementation group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.5'
+
+	// AWS
+	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/triprecord/triprecord/global/config/S3Config.java
+++ b/src/main/java/com/triprecord/triprecord/global/config/S3Config.java
@@ -1,0 +1,31 @@
+package com.triprecord.triprecord.global.config;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class S3Config {
+
+    @Value("${aws.s3.accessKey}")
+    private String accessKey;
+    @Value("${aws.s3.secretKey}")
+    private String secretKey;
+    @Value("${aws.region}")
+    private String region;
+
+    @Bean
+    public AmazonS3Client amazonS3ClientBuilder() {
+        AWSCredentials credentials = new BasicAWSCredentials(accessKey, secretKey);
+        return (AmazonS3Client) AmazonS3ClientBuilder
+                .standard()
+                .withCredentials(new AWSStaticCredentialsProvider(credentials))
+                .withRegion(region)
+                .build();
+    }
+}

--- a/src/main/java/com/triprecord/triprecord/global/exception/ErrorCode.java
+++ b/src/main/java/com/triprecord/triprecord/global/exception/ErrorCode.java
@@ -11,7 +11,8 @@ public enum ErrorCode {
 
     USER_NOT_FOUND(HttpStatus.NOT_FOUND,"유저 정보를 찾을 수 없습니다."),
     DUPLICATE_EMAIL(HttpStatus.CONFLICT, "이미 존재하는 이메일입니다."),
-    INVALID_PASSWORD(HttpStatus.UNAUTHORIZED,"비밀번호가 일치하지 않습니다.");
+    INVALID_PASSWORD(HttpStatus.UNAUTHORIZED,"비밀번호가 일치하지 않습니다."),
+    FILE_READ_FAILED(HttpStatus.INTERNAL_SERVER_ERROR,"파일 읽기에 실패했습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/triprecord/triprecord/global/util/S3Service.java
+++ b/src/main/java/com/triprecord/triprecord/global/util/S3Service.java
@@ -1,0 +1,40 @@
+package com.triprecord.triprecord.global.util;
+
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.triprecord.triprecord.global.exception.ErrorCode;
+import com.triprecord.triprecord.global.exception.TripRecordException;
+import java.io.IOException;
+import java.net.URL;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+@RequiredArgsConstructor
+public class S3Service {
+    @Value("${aws.s3.bucket.name}")
+    private String bucket;
+    private final AmazonS3Client S3Client;
+
+    public void uploadFileToS3(final MultipartFile file, final String fileName) {
+        ObjectMetadata metadata = new ObjectMetadata();
+        metadata.setContentType(file.getContentType());
+        metadata.setContentLength(file.getSize());
+        try {
+            S3Client.putObject(
+                    new PutObjectRequest(bucket, fileName, file.getInputStream(), metadata)
+            );
+        } catch (IOException e) {
+            throw new TripRecordException(ErrorCode.FILE_READ_FAILED);
+        }
+    }
+
+    public URL getFileURLFromS3(final String fileName) {
+        return S3Client.getUrl(bucket, fileName);
+    }
+
+}


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- feat/#17 -> dev
- close #17

## Key Changes
<!-- 최대한 자세히 -->
파일을 지정된 이름으로 S3에 업로드하는 기능, 파일 이름을 통해 해당 파일의 S3 URL 을 얻는 기능
- 이미지로 국한되지 않고 파일을 업로드하는 형식으로 구현했습니다.
- S3Service는 Util 패키지로 분류했습니다.
 - PR에 포함되지 않은, 테스트를 위해 사용한 로직은 다음과 같습니다.
```java
private final S3Service s3Service;

    @PostMapping("/test/upload")
    public String s3test(@RequestParam("images") MultipartFile multipartFile){
        String uploadFileName = getNameAddRandomUUID(multipartFile.getOriginalFilename());
        s3Service.uploadFileToS3(multipartFile, uploadFileName);
        return s3Service.getFileURLFromS3(uploadFileName).toString();
    }

    private String getNameAddRandomUUID(String originName) {
        String randomUUID = UUID.randomUUID().toString();
        return randomUUID+originName;
    }
```
이미지 업로드를 test 했으며, 반환되는 URL 에 접속 시 업로드한 이미지 확인이 가능합니다.
## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->
- properties에 들어갈 S3 관련 내용을 공유 문서에 추가했습니다.
- Cross-Account 를 사용하지 않기 때문에, S3 버킷의 객체 소유권 ACL을 활성화 하지 않았습니다. 
- 이미지 이름 중복을 피하기 위한 랜덤 UUID를 기존 파일명과 합치는 로직을 S3Service가 아닌 Service를 호출하는 쪽에 배치했습니다. getURL과 uploadFile 기능을 분리하고 싶었던 것이 제일 큰 이유인데, 해당 내용에 대한 의견도 궁금하네요!
- S3에 없는 파일 명으로 getURL을 했을때의 처리를 하고 싶어서 테스트를 해봤는데, 이상한 파일명을 넘겨서 getURL을 해도 URL이 리턴되긴 하더라구요 (누르면 뜨는건 없음). 해당 내용에 대한 아이디어가 떠오르시면 공유해주시면 감사하겠습니다~

질문이나 의견 편하게 많이 주세요~😃
## References
<!-- 참고한 자료-->
- ACL관련 https://dobby-isfree.tistory.com/191
- S3 메서드 관련 https://github.com/awsdocs/aws-doc-sdk-examples/tree/main/java/example_code/s3