### PR TITLE
[FEAT] 기록 생성 API

### DIFF
--- a/src/main/java/com/triprecord/triprecord/global/exception/ErrorCode.java
+++ b/src/main/java/com/triprecord/triprecord/global/exception/ErrorCode.java
@@ -12,7 +12,9 @@ public enum ErrorCode {
     USER_NOT_FOUND(HttpStatus.NOT_FOUND,"유저 정보를 찾을 수 없습니다."),
     DUPLICATE_EMAIL(HttpStatus.CONFLICT, "이미 존재하는 이메일입니다."),
     INVALID_PASSWORD(HttpStatus.UNAUTHORIZED,"비밀번호가 일치하지 않습니다."),
-    FILE_READ_FAILED(HttpStatus.INTERNAL_SERVER_ERROR,"파일 읽기에 실패했습니다.");
+    FILE_READ_FAILED(HttpStatus.INTERNAL_SERVER_ERROR,"파일 읽기에 실패했습니다."),
+
+    PLACE_NOT_FOUNT(HttpStatus.NOT_FOUND,"일치하는 장소가 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/triprecord/triprecord/global/exception/GlobalControllerAdvice.java
+++ b/src/main/java/com/triprecord/triprecord/global/exception/GlobalControllerAdvice.java
@@ -22,7 +22,7 @@ public class GlobalControllerAdvice {
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ExceptionDTO> methodArgumentNotValidException(final MethodArgumentNotValidException e){
         log.error(String.format(ERROR_LOG, e.getParameter(), "객체검증에러"));
-        return ResponseEntity.badRequest().body(new ExceptionDTO("필요한 데이터가 모두 입력되지 않았습니다."));
+        return ResponseEntity.badRequest().body(new ExceptionDTO("전달된 데이터에 오류가 있습니다."));
     }
 
     @ExceptionHandler(RuntimeException.class)

--- a/src/main/java/com/triprecord/triprecord/location/PlaceRepository.java
+++ b/src/main/java/com/triprecord/triprecord/location/PlaceRepository.java
@@ -1,0 +1,12 @@
+package com.triprecord.triprecord.location;
+
+
+import com.triprecord.triprecord.location.entity.Place;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PlaceRepository extends JpaRepository<Place, Long> {
+    Optional<Place> findByPlaceId(Long placeId);
+}

--- a/src/main/java/com/triprecord/triprecord/record/controller/RecordController.java
+++ b/src/main/java/com/triprecord/triprecord/record/controller/RecordController.java
@@ -4,6 +4,7 @@ package com.triprecord.triprecord.record.controller;
 import com.triprecord.triprecord.record.controller.request.RecordCreateRequest;
 import com.triprecord.triprecord.record.service.RecordService;
 import jakarta.validation.Valid;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -21,9 +22,9 @@ public class RecordController {
     private final RecordService recordService;
 
     @PostMapping()
-    public ResponseEntity<String> createRecord(Authentication authentication, @Valid RecordCreateRequest request){
+    public ResponseEntity<Map<String, String>> createRecord(Authentication authentication, @Valid RecordCreateRequest request){
         recordService.createRecord(Long.valueOf(authentication.getName()), request);
-        return ResponseEntity.status(HttpStatus.CREATED).body("기록 생성에 성공했습니다.");
+        return ResponseEntity.status(HttpStatus.CREATED).body(Map.of("message","기록 생성에 성공했습니다."));
     }
 
 }

--- a/src/main/java/com/triprecord/triprecord/record/controller/RecordController.java
+++ b/src/main/java/com/triprecord/triprecord/record/controller/RecordController.java
@@ -16,7 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/record")
+@RequestMapping("/records")
 public class RecordController {
 
     private final RecordService recordService;

--- a/src/main/java/com/triprecord/triprecord/record/controller/RecordController.java
+++ b/src/main/java/com/triprecord/triprecord/record/controller/RecordController.java
@@ -1,0 +1,29 @@
+package com.triprecord.triprecord.record.controller;
+
+
+import com.triprecord.triprecord.record.controller.request.RecordCreateRequest;
+import com.triprecord.triprecord.record.service.RecordService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/record")
+public class RecordController {
+
+    private final RecordService recordService;
+
+    @PostMapping()
+    public ResponseEntity<String> createRecord(Authentication authentication, @Valid RecordCreateRequest request){
+        recordService.createRecord(Long.valueOf(authentication.getName()), request);
+        return ResponseEntity.status(HttpStatus.CREATED).body("기록 생성에 성공했습니다.");
+    }
+
+}

--- a/src/main/java/com/triprecord/triprecord/record/controller/request/RecordCreateRequest.java
+++ b/src/main/java/com/triprecord/triprecord/record/controller/request/RecordCreateRequest.java
@@ -11,7 +11,7 @@ public record RecordCreateRequest(
         @NotNull String recordContent,
         @NotNull LocalDate startDate,
         @NotNull LocalDate endDate,
-        @Size(min = 1, max = 3) List<Long> placeIds,
+        @NotNull @Size(min = 1, max = 3) List<Long> placeIds,
         @Size(max = 10) List<MultipartFile> recordImages
         ) {
 }

--- a/src/main/java/com/triprecord/triprecord/record/controller/request/RecordCreateRequest.java
+++ b/src/main/java/com/triprecord/triprecord/record/controller/request/RecordCreateRequest.java
@@ -1,0 +1,17 @@
+package com.triprecord.triprecord.record.controller.request;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.time.LocalDate;
+import java.util.List;
+import org.springframework.web.multipart.MultipartFile;
+
+public record RecordCreateRequest(
+        @NotNull String recordTitle,
+        @NotNull String recordContent,
+        @NotNull LocalDate startDate,
+        @NotNull LocalDate endDate,
+        @Size(min = 1, max = 3) List<Long> placeIds,
+        @Size(max = 10) List<MultipartFile> recordImages
+        ) {
+}

--- a/src/main/java/com/triprecord/triprecord/record/entity/Record.java
+++ b/src/main/java/com/triprecord/triprecord/record/entity/Record.java
@@ -52,12 +52,12 @@ public class Record {
     private List<RecordImage> recordImages = new ArrayList<>();
 
     @Builder
-    public Record(String recordTitle, String recordContent, LocalDate tripStartDate, LocalDate tripEndDate, User user) {
+    public Record(String recordTitle, String recordContent, LocalDate tripStartDate, LocalDate tripEndDate, User createdUser) {
         this.recordTitle = recordTitle;
         this.recordContent = recordContent;
         this.tripStartDate = tripStartDate;
         this.tripEndDate = tripEndDate;
-        this.createdUser = user;
+        this.createdUser = createdUser;
     }
 
 }

--- a/src/main/java/com/triprecord/triprecord/record/entity/RecordImage.java
+++ b/src/main/java/com/triprecord/triprecord/record/entity/RecordImage.java
@@ -23,15 +23,15 @@ public class RecordImage {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long recordImgId;
 
-    private String recordImg;
+    private String recordImgUrl;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "record_id")
     private Record linkedRecord;
 
     @Builder
-    public RecordImage(String recordImg, Record record) {
-        this.recordImg = recordImg;
-        this.linkedRecord = record;
+    public RecordImage(String imageURL, Record linkedRecord) {
+        this.recordImgUrl = imageURL;
+        this.linkedRecord = linkedRecord;
     }
 }

--- a/src/main/java/com/triprecord/triprecord/record/entity/RecordPlace.java
+++ b/src/main/java/com/triprecord/triprecord/record/entity/RecordPlace.java
@@ -32,8 +32,8 @@ public class RecordPlace {
     private Place recordPlace;
 
     @Builder
-    public RecordPlace(Record record, Place place) {
-        this.linkedRecord = record;
-        this.recordPlace = place;
+    public RecordPlace(Record linkedRecord, Place recordPlace) {
+        this.linkedRecord = linkedRecord;
+        this.recordPlace = recordPlace;
     }
 }

--- a/src/main/java/com/triprecord/triprecord/record/repository/RecordImageRepository.java
+++ b/src/main/java/com/triprecord/triprecord/record/repository/RecordImageRepository.java
@@ -1,0 +1,9 @@
+package com.triprecord.triprecord.record.repository;
+
+import com.triprecord.triprecord.record.entity.RecordImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface RecordImageRepository extends JpaRepository<RecordImage, Long> {
+}

--- a/src/main/java/com/triprecord/triprecord/record/repository/RecordPlaceRepository.java
+++ b/src/main/java/com/triprecord/triprecord/record/repository/RecordPlaceRepository.java
@@ -2,6 +2,8 @@ package com.triprecord.triprecord.record.repository;
 
 import com.triprecord.triprecord.record.entity.RecordPlace;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface RecordPlaceRepository extends JpaRepository<RecordPlace, Long> {
 }

--- a/src/main/java/com/triprecord/triprecord/record/repository/RecordPlaceRepository.java
+++ b/src/main/java/com/triprecord/triprecord/record/repository/RecordPlaceRepository.java
@@ -1,0 +1,7 @@
+package com.triprecord.triprecord.record.repository;
+
+import com.triprecord.triprecord.record.entity.RecordPlace;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RecordPlaceRepository extends JpaRepository<RecordPlace, Long> {
+}

--- a/src/main/java/com/triprecord/triprecord/record/repository/RecordRepository.java
+++ b/src/main/java/com/triprecord/triprecord/record/repository/RecordRepository.java
@@ -1,0 +1,11 @@
+package com.triprecord.triprecord.record.repository;
+
+
+import com.triprecord.triprecord.record.entity.Record;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface RecordRepository extends JpaRepository<Record, Long> {
+
+}

--- a/src/main/java/com/triprecord/triprecord/record/service/RecordImageService.java
+++ b/src/main/java/com/triprecord/triprecord/record/service/RecordImageService.java
@@ -1,0 +1,38 @@
+package com.triprecord.triprecord.record.service;
+
+import com.triprecord.triprecord.global.util.S3Service;
+import com.triprecord.triprecord.record.entity.Record;
+import com.triprecord.triprecord.record.entity.RecordImage;
+import com.triprecord.triprecord.record.repository.RecordImageRepository;
+import java.net.URL;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+@RequiredArgsConstructor
+public class RecordImageService {
+
+    private final S3Service s3Service;
+    private final RecordImageRepository recordImageRepository;
+
+    @Transactional
+    public void uploadRecordImage(MultipartFile image, Record record){
+        String uploadName = getNameAddRandomUUID(image.getOriginalFilename());
+        s3Service.uploadFileToS3(image, uploadName);
+        String imageURL = s3Service.getFileURLFromS3(uploadName).toString();
+        RecordImage recordImage = RecordImage.builder()
+                .linkedRecord(record)
+                .imageURL(imageURL)
+                .build();
+        recordImageRepository.save(recordImage);
+    }
+
+
+    private String getNameAddRandomUUID(String originName) {
+        String randomUUID = UUID.randomUUID().toString();
+        return randomUUID+originName;
+    }
+}

--- a/src/main/java/com/triprecord/triprecord/record/service/RecordPlaceService.java
+++ b/src/main/java/com/triprecord/triprecord/record/service/RecordPlaceService.java
@@ -1,0 +1,36 @@
+package com.triprecord.triprecord.record.service;
+
+
+import com.triprecord.triprecord.global.exception.ErrorCode;
+import com.triprecord.triprecord.global.exception.TripRecordException;
+import com.triprecord.triprecord.location.PlaceRepository;
+import com.triprecord.triprecord.location.entity.Place;
+import com.triprecord.triprecord.record.entity.Record;
+import com.triprecord.triprecord.record.entity.RecordPlace;
+import com.triprecord.triprecord.record.repository.RecordPlaceRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class RecordPlaceService {
+
+    private final PlaceRepository placeRepository;
+    private final RecordPlaceRepository recordPlaceRepository;
+
+    @Transactional
+    public void uploadRecordPlace(Record record, Long placeId){
+        Place linkedPlace = getPlaceOrException(placeId);
+        RecordPlace recordPlace = RecordPlace.builder()
+                .recordPlace(linkedPlace)
+                .linkedRecord(record)
+                .build();
+        recordPlaceRepository.save(recordPlace);
+    }
+
+    private Place getPlaceOrException(Long placeId) {
+        return placeRepository.findByPlaceId(placeId).orElseThrow(() ->
+                new TripRecordException(ErrorCode.PLACE_NOT_FOUNT));
+    }
+}

--- a/src/main/java/com/triprecord/triprecord/record/service/RecordService.java
+++ b/src/main/java/com/triprecord/triprecord/record/service/RecordService.java
@@ -1,0 +1,53 @@
+package com.triprecord.triprecord.record.service;
+
+import com.triprecord.triprecord.global.exception.ErrorCode;
+import com.triprecord.triprecord.global.exception.TripRecordException;
+import com.triprecord.triprecord.record.entity.Record;
+import com.triprecord.triprecord.record.entity.RecordPlace;
+import com.triprecord.triprecord.record.repository.RecordPlaceRepository;
+import com.triprecord.triprecord.record.repository.RecordRepository;
+import com.triprecord.triprecord.record.controller.request.RecordCreateRequest;
+import com.triprecord.triprecord.user.entity.User;
+import com.triprecord.triprecord.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RecordService {
+
+    private final UserRepository userRepository;
+    private final RecordRepository recordRepository;
+    private final RecordImageService recordImageService;
+    private final RecordPlaceService recordPlaceService;
+
+    @Transactional
+    public void createRecord(Long userId, RecordCreateRequest request){
+        User createdUser = getUserOrException(userId);
+        Record record = Record.builder()
+                .recordTitle(request.recordTitle())
+                .recordContent(request.recordContent())
+                .tripStartDate(request.startDate())
+                .tripEndDate(request.endDate())
+                .createdUser(createdUser)
+                .build();
+        recordRepository.save(record);
+        for(Long placeId : request.placeIds()){
+            recordPlaceService.uploadRecordPlace(record, placeId);
+        }
+        if(request.recordImages()==null) return;
+        for(MultipartFile image : request.recordImages()){
+            recordImageService.uploadRecordImage(image, record);
+        }
+    }
+
+    private User getUserOrException(Long userId) {
+        return userRepository.findById(userId).orElseThrow(() ->
+                new TripRecordException(ErrorCode.USER_NOT_FOUND));
+    }
+
+}

--- a/src/main/java/com/triprecord/triprecord/record/service/RecordService.java
+++ b/src/main/java/com/triprecord/triprecord/record/service/RecordService.java
@@ -9,6 +9,7 @@ import com.triprecord.triprecord.record.repository.RecordRepository;
 import com.triprecord.triprecord.record.controller.request.RecordCreateRequest;
 import com.triprecord.triprecord.user.entity.User;
 import com.triprecord.triprecord.user.repository.UserRepository;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -36,12 +37,20 @@ public class RecordService {
                 .createdUser(createdUser)
                 .build();
         recordRepository.save(record);
-        for(Long placeId : request.placeIds()){
-            recordPlaceService.uploadRecordPlace(record, placeId);
+        uploadPlace(request.placeIds(), record);
+        uploadImage(request.recordImages(), record);
+    }
+
+    private void uploadPlace(List<Long> placeIds, Record linkedRecord){
+        for(Long placeId : placeIds){
+            recordPlaceService.uploadRecordPlace(linkedRecord, placeId);
         }
-        if(request.recordImages()==null) return;
-        for(MultipartFile image : request.recordImages()){
-            recordImageService.uploadRecordImage(image, record);
+    }
+
+    private void uploadImage(List<MultipartFile> images, Record linkedRecord){
+        if(images==null) return;
+        for(MultipartFile image : images){
+            recordImageService.uploadRecordImage(image, linkedRecord);
         }
     }
 


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- feat/#20 -> dev
- close #20

## Key Changes
<!-- 최대한 자세히 -->
### POST /records 요청시 기록을 생성하는 API 개발


- 필요한 데이터는 form-data 형식으로 받도록 합니다.
postman 요청의 예제입니다.

![image](https://github.com/Trip-Record/Server/assets/105481797/cdad8359-fdcc-4153-a1f1-ceddddfcf2e3)


**성공시** 

201 상태코드와 함께 성공 메세지를 반환합니다.

![image](https://github.com/Trip-Record/Server/assets/105481797/095c34d4-497f-42e7-8cdf-bed30c48c19a)

**오류가 발생되는 상황**
- 사진 외의 모든 값들이 포함되지 않았을 경우
- 사진 장수가 10 초과되는 경우
- 장소 id의 개수가 3 초과되는 경우

![image](https://github.com/Trip-Record/Server/assets/105481797/88c1ce65-3d46-453c-8628-1793e0865627)




## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->
- #21 에서 언급한 내용이 포함되어 있습니다.

- 현재 성공 메세지 반환시 Map으로 message:{메세지} 형식으로 반환되게 했는데,
에러메세지를 반환하는 경우처럼 성공메시지반환 DTO를 만들어 전역으로 사용하면 좋을 것 같습니다.

- 기록 생성 서비스에서 image가 null일때 (기록에 첨부되는 이미지가 없을 때) 
`if(images==null) return;`으로 처리 후 밑에서 레코드 이미지를 생성하는 로직이 있습니다.
근데 메서드 자체는 void라서 return을 쓰지 말까 싶었는데 !=null로 빼면 또 가독성이 별로인것 같아서 계속 고민이 되더라구요. 해당 로직 관련해서 좋은 의견 생각나시면 말해주시면 감사하겠습니다!

네이밍이나 로직 등 코드 관련 궁금한점, 개선할점 등 편하게 의견 많이 주세요!!!😃

## References
<!-- 참고한 자료-->
