### PR TITLE
[FEAT] 일정 생성 API 구현

### DIFF
--- a/src/main/java/com/triprecord/triprecord/global/exception/ErrorCode.java
+++ b/src/main/java/com/triprecord/triprecord/global/exception/ErrorCode.java
@@ -9,12 +9,15 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum ErrorCode {
 
-    USER_NOT_FOUND(HttpStatus.NOT_FOUND,"유저 정보를 찾을 수 없습니다."),
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "유저 정보를 찾을 수 없습니다."),
     DUPLICATE_EMAIL(HttpStatus.CONFLICT, "이미 존재하는 이메일입니다."),
-    INVALID_PASSWORD(HttpStatus.UNAUTHORIZED,"비밀번호가 일치하지 않습니다."),
-    FILE_READ_FAILED(HttpStatus.INTERNAL_SERVER_ERROR,"파일 읽기에 실패했습니다."),
+    INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "비밀번호가 일치하지 않습니다."),
+    FILE_READ_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "파일 읽기에 실패했습니다."),
 
-    PLACE_NOT_FOUNT(HttpStatus.NOT_FOUND,"일치하는 장소가 없습니다.");
+    PLACE_NOT_FOUNT(HttpStatus.NOT_FOUND, "일치하는 장소가 없습니다."),
+
+    SCHEDULE_DATE_INVALID(HttpStatus.BAD_REQUEST, "일정 기간이 유효하지 않습니다."),
+    SCHEDULE_DETAIL_DATE_INVALID(HttpStatus.BAD_REQUEST, "일정 상세 날짜가 일정 기간을 벗어났습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/triprecord/triprecord/location/PlaceRepository.java
+++ b/src/main/java/com/triprecord/triprecord/location/PlaceRepository.java
@@ -2,9 +2,10 @@ package com.triprecord.triprecord.location;
 
 
 import com.triprecord.triprecord.location.entity.Place;
-import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
 
 @Repository
 public interface PlaceRepository extends JpaRepository<Place, Long> {

--- a/src/main/java/com/triprecord/triprecord/schedule/controller/ScheduleController.java
+++ b/src/main/java/com/triprecord/triprecord/schedule/controller/ScheduleController.java
@@ -1,0 +1,33 @@
+package com.triprecord.triprecord.schedule.controller;
+
+import com.triprecord.triprecord.schedule.dto.request.ScheduleCreateRequest;
+import com.triprecord.triprecord.schedule.service.ScheduleService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/schedules")
+public class ScheduleController {
+
+    private final ScheduleService scheduleService;
+
+    @PostMapping
+    public ResponseEntity<Map<String, String>> createSchedule(Authentication authentication, @RequestBody @Valid ScheduleCreateRequest request) {
+        Long userId = Long.valueOf(authentication.getName());
+        scheduleService.createSchedule(userId, request);
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(Map.of("message", "일정 생성에 성공했습니다."));
+    }
+
+}

--- a/src/main/java/com/triprecord/triprecord/schedule/dto/request/ScheduleCreateRequest.java
+++ b/src/main/java/com/triprecord/triprecord/schedule/dto/request/ScheduleCreateRequest.java
@@ -1,0 +1,19 @@
+package com.triprecord.triprecord.schedule.dto.request;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public record ScheduleCreateRequest(
+        @NotBlank String scheduleTitle,
+        @NotEmpty @Size(min = 1, max = 3) List<Long> schedulePlaceIds,
+        @NotNull LocalDate scheduleStartDate,
+        @NotNull LocalDate scheduleEndDate,
+        @Valid @NotNull List<ScheduleDetailCreateRequest> scheduleDetails
+) {
+}

--- a/src/main/java/com/triprecord/triprecord/schedule/dto/request/ScheduleDetailCreateRequest.java
+++ b/src/main/java/com/triprecord/triprecord/schedule/dto/request/ScheduleDetailCreateRequest.java
@@ -1,0 +1,12 @@
+package com.triprecord.triprecord.schedule.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import java.time.LocalDate;
+
+public record ScheduleDetailCreateRequest(
+        @NotNull LocalDate scheduleDetailDate,
+        @NotBlank String scheduleDetailContent
+) {
+}

--- a/src/main/java/com/triprecord/triprecord/schedule/entity/ScheduleDetail.java
+++ b/src/main/java/com/triprecord/triprecord/schedule/entity/ScheduleDetail.java
@@ -1,6 +1,5 @@
 package com.triprecord.triprecord.schedule.entity;
 
-import com.triprecord.triprecord.schedule.entity.Schedule;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -8,11 +7,12 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import java.time.LocalDate;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
 
 @Entity
 @Getter
@@ -33,8 +33,8 @@ public class ScheduleDetail {
 
 
     @Builder
-    public ScheduleDetail(LocalDate localDate, String content, Schedule schedule) {
-        this.scheduleDetailDate = localDate;
+    public ScheduleDetail(LocalDate scheduleDetailDate, String content, Schedule schedule) {
+        this.scheduleDetailDate = scheduleDetailDate;
         this.scheduleContent = content;
         this.linkedSchedule = schedule;
     }

--- a/src/main/java/com/triprecord/triprecord/schedule/repository/ScheduleDetailRepository.java
+++ b/src/main/java/com/triprecord/triprecord/schedule/repository/ScheduleDetailRepository.java
@@ -1,0 +1,9 @@
+package com.triprecord.triprecord.schedule.repository;
+
+import com.triprecord.triprecord.schedule.entity.ScheduleDetail;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ScheduleDetailRepository extends JpaRepository<ScheduleDetail, Long> {
+}

--- a/src/main/java/com/triprecord/triprecord/schedule/repository/SchedulePlaceRepository.java
+++ b/src/main/java/com/triprecord/triprecord/schedule/repository/SchedulePlaceRepository.java
@@ -1,0 +1,9 @@
+package com.triprecord.triprecord.schedule.repository;
+
+import com.triprecord.triprecord.schedule.entity.SchedulePlace;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface SchedulePlaceRepository extends JpaRepository<SchedulePlace, Long> {
+}

--- a/src/main/java/com/triprecord/triprecord/schedule/repository/ScheduleRepository.java
+++ b/src/main/java/com/triprecord/triprecord/schedule/repository/ScheduleRepository.java
@@ -1,0 +1,9 @@
+package com.triprecord.triprecord.schedule.repository;
+
+import com.triprecord.triprecord.schedule.entity.Schedule;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
+}

--- a/src/main/java/com/triprecord/triprecord/schedule/service/ScheduleService.java
+++ b/src/main/java/com/triprecord/triprecord/schedule/service/ScheduleService.java
@@ -1,0 +1,97 @@
+package com.triprecord.triprecord.schedule.service;
+
+import com.triprecord.triprecord.global.exception.ErrorCode;
+import com.triprecord.triprecord.global.exception.TripRecordException;
+import com.triprecord.triprecord.location.PlaceRepository;
+import com.triprecord.triprecord.location.entity.Place;
+import com.triprecord.triprecord.schedule.dto.request.ScheduleCreateRequest;
+import com.triprecord.triprecord.schedule.entity.Schedule;
+import com.triprecord.triprecord.schedule.entity.ScheduleDetail;
+import com.triprecord.triprecord.schedule.entity.SchedulePlace;
+import com.triprecord.triprecord.schedule.repository.ScheduleDetailRepository;
+import com.triprecord.triprecord.schedule.repository.SchedulePlaceRepository;
+import com.triprecord.triprecord.schedule.repository.ScheduleRepository;
+import com.triprecord.triprecord.user.entity.User;
+import com.triprecord.triprecord.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ScheduleService {
+
+    private final ScheduleRepository scheduleRepository;
+    private final PlaceRepository placeRepository;
+    private final UserRepository userRepository;
+    private final SchedulePlaceRepository schedulePlaceRepository;
+    private final ScheduleDetailRepository scheduleDetailRepository;
+
+    @Transactional
+    public void createSchedule(Long userId, ScheduleCreateRequest request) {
+        User user = getUserOrException(userId);
+
+        List<Place> places = new ArrayList<>();
+        for (Long placeId : request.schedulePlaceIds()) {
+            places.add(getPlaceOrException(placeId));
+        }
+
+        if (request.scheduleStartDate().isAfter(request.scheduleEndDate())) {
+            throw new TripRecordException(ErrorCode.SCHEDULE_DATE_INVALID);
+        }
+
+        Schedule schedule = Schedule.builder()
+                .scheduleTitle(request.scheduleTitle())
+                .startDate(request.scheduleStartDate())
+                .endDate(request.scheduleEndDate())
+                .user(user)
+                .build();
+        scheduleRepository.save(schedule);
+
+        for (Place place : places) {
+            SchedulePlace schedulePlace = SchedulePlace.builder()
+                    .schedule(schedule)
+                    .place(place)
+                    .build();
+            schedulePlaceRepository.save(schedulePlace);
+        }
+
+        if (request.scheduleDetails().isEmpty()) return;
+
+        request.scheduleDetails().stream()
+                .filter(scheduleDetail -> isNotBetweenInclusive(scheduleDetail.scheduleDetailDate(), request.scheduleStartDate(), request.scheduleEndDate()))
+                .findAny()
+                .ifPresent(scheduleDetail -> {
+                    throw new TripRecordException(ErrorCode.SCHEDULE_DETAIL_DATE_INVALID);
+                });
+
+        request.scheduleDetails().stream()
+                .map(scheduleDetail -> ScheduleDetail.builder()
+                        .schedule(schedule)
+                        .scheduleDetailDate(scheduleDetail.scheduleDetailDate())
+                        .content(scheduleDetail.scheduleDetailContent())
+                        .build())
+                .forEach(scheduleDetailRepository::save);
+    }
+
+    private User getUserOrException(Long userId) {
+        return userRepository.findById(userId).orElseThrow(() ->
+                new TripRecordException(ErrorCode.USER_NOT_FOUND));
+    }
+
+    private Place getPlaceOrException(Long placeId) {
+        return placeRepository.findById(placeId).orElseThrow(() ->
+                new TripRecordException(ErrorCode.PLACE_NOT_FOUNT));
+    }
+
+    private static boolean isNotBetweenInclusive(LocalDate dateToCheck, LocalDate startDate, LocalDate endDate) {
+        return !(dateToCheck.isEqual(startDate) || dateToCheck.isAfter(startDate))
+                || !(dateToCheck.isEqual(endDate) || dateToCheck.isBefore(endDate));
+    }
+
+}

--- a/src/main/java/com/triprecord/triprecord/schedule/service/ScheduleService.java
+++ b/src/main/java/com/triprecord/triprecord/schedule/service/ScheduleService.java
@@ -71,12 +71,7 @@ public class ScheduleService {
                 });
 
         request.scheduleDetails().stream()
-                .map(scheduleDetail -> ScheduleDetail.builder()
-                        .schedule(schedule)
-                        .scheduleDetailDate(scheduleDetail.scheduleDetailDate())
-                        .content(scheduleDetail.scheduleDetailContent())
-                        .build())
-                .forEach(scheduleDetailRepository::save);
+                .forEach(scheduleDetail -> createScheduleDetail(schedule, scheduleDetail.scheduleDetailDate(), scheduleDetail.scheduleDetailContent()));
     }
 
     private User getUserOrException(Long userId) {
@@ -92,6 +87,15 @@ public class ScheduleService {
     private static boolean isNotBetweenInclusive(LocalDate dateToCheck, LocalDate startDate, LocalDate endDate) {
         return !(dateToCheck.isEqual(startDate) || dateToCheck.isAfter(startDate))
                 || !(dateToCheck.isEqual(endDate) || dateToCheck.isBefore(endDate));
+    }
+
+    private void createScheduleDetail(Schedule schedule, LocalDate scheduleDetailDate, String scheduleDetailContent) {
+        ScheduleDetail scheduleDetail = ScheduleDetail.builder()
+                .schedule(schedule)
+                .scheduleDetailDate(scheduleDetailDate)
+                .content(scheduleDetailContent)
+                .build();
+        scheduleDetailRepository.save(scheduleDetail);
     }
 
 }


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- feat/#23 -> dev
- close #23

## Key Changes
<!-- 최대한 자세히 -->
일정 관련 정보를 받아서 일정, 세부 일정, 일정장소를 생성하는 API를 구현했습니다.
일정 안에 존재하는 세부 일정은 일정의 시작일부터 마지막일까지 존재하지만, 세부 일정 내용을 작성하지 않은 일자는 DB에는 저장하지 않음으로써 작성하지 않은 세부 일정으로 취급합니다.

해당 API의 로직은 다음과 같습니다.
> 1. 일정 정보들을 받아온다.
> 2. 헤더의 유저 토큰으로 유저 정보를 알아낸다. (없으면 에러 발생)
> 3. 받아온 일정 장소들(1~3개)이 DB에 존재하는지 확인한다. (없으면 에러 발생)
> 4. 일정의 시작일과 종료일이 올바른지 확인한다. (올바르지 않으면 에러 발생)
> 5. 일정을 DB에 저장한다.
> 6. 일정 장소를 DB에 저장한다.
> 7. 세부 일정이 있는지 확인 후, 있다면 세부 일정의 일자가 큰 일정의 기간에 속하는지 검사한다. (아닐 시 에러 발생)
> 8. 세부 일정을 DB에 저장한다.

<br>

DTO 내부에 또 다른 DTO를 사용할 때, 내부 DTO의 검증은 @Valid 어노테이션을 사용했습니다.
```java
public record ScheduleCreateRequest(
        ...
        @Valid @NotNull List<ScheduleDetailCreateRequest> scheduleDetails
) {
}
``` 

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->
일정 생성의 주의 깊게 보면 좋을 예외처리는 다음과 같습니다. (이 외 다른 예외처리도 있습니다!)
1. _일정 제목이 빈 문자열인가?_
2. _일정 장소가 1~3개 선택되었는가?_
3. _세부 일정 내용이 빈 문자열인가?_
4. _일정 종료일이 시작일 후인가?_
5. _세부 일정 일자가 일정 시작일~종료일 사이인가?_

생각나는대로 예외처리를 하긴 했는데, 어디까지 예외처리를 해야할지 잘 감이 안오네용,,!
혹시 추가해야 할 예외나 다른 부분에서 궁금한점, 수정할 점이 있다면 말씀주세요!!

## References
<!-- 참고한 자료-->
X