### PR TITLE
[FEAT] 공통 응답 메시지

### DIFF
--- a/src/main/java/com/triprecord/triprecord/global/util/ResponseMessage.java
+++ b/src/main/java/com/triprecord/triprecord/global/util/ResponseMessage.java
@@ -1,0 +1,6 @@
+package com.triprecord.triprecord.global.util;
+
+public record ResponseMessage(
+        String message
+) {
+}

--- a/src/main/java/com/triprecord/triprecord/record/controller/RecordController.java
+++ b/src/main/java/com/triprecord/triprecord/record/controller/RecordController.java
@@ -1,6 +1,7 @@
 package com.triprecord.triprecord.record.controller;
 
 
+import com.triprecord.triprecord.global.util.ResponseMessage;
 import com.triprecord.triprecord.record.controller.request.RecordCreateRequest;
 import com.triprecord.triprecord.record.service.RecordService;
 import jakarta.validation.Valid;
@@ -22,9 +23,11 @@ public class RecordController {
     private final RecordService recordService;
 
     @PostMapping()
-    public ResponseEntity<Map<String, String>> createRecord(Authentication authentication, @Valid RecordCreateRequest request){
+    public ResponseEntity<ResponseMessage> createRecord(Authentication authentication, @Valid RecordCreateRequest request){
         recordService.createRecord(Long.valueOf(authentication.getName()), request);
-        return ResponseEntity.status(HttpStatus.CREATED).body(Map.of("message","기록 생성에 성공했습니다."));
+        return ResponseEntity.status(HttpStatus.CREATED).body(new ResponseMessage("기록 생성에 성공했습니다."));
     }
+
+
 
 }


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- feat/#28 -> dev
- close #28

## Key Changes
<!-- 최대한 자세히 -->
성공 문자를 반환할 경우 공통으로 사용할 응답 메시지를 만들었습니다.
이에 따라 기존 `message:{응답메세지}` 포멧의 응답을 Map으로 주던 방식에서
공통으로 사용할 Response DTO를 반환하도록 수정했습니다.

반환 형식입니다.

![image](https://github.com/Trip-Record/Server/assets/105481797/427bc59f-d958-4a72-aceb-88f534630a37)

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->
String값으로 응답을 보낼때 밑 방식으로 보내면 될 것 같습니다 !
```java
new ResponseMessage("기록 생성에 성공했습니다.")
```
개선할 점이나 의견, 궁금한점 말해주세요 ! 😃

## References
<!-- 참고한 자료-->
