### PR TITLE
[FEAT] 일정 삭제 API 구현

### DIFF
--- a/src/main/java/com/triprecord/triprecord/global/exception/ErrorCode.java
+++ b/src/main/java/com/triprecord/triprecord/global/exception/ErrorCode.java
@@ -15,15 +15,13 @@ public enum ErrorCode {
     FILE_READ_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "파일 읽기에 실패했습니다."),
     PLACE_NOT_FOUNT(HttpStatus.NOT_FOUND, "일치하는 장소가 없습니다."),
     RECORD_NOT_FOUND(HttpStatus.NOT_FOUND, "기록을 찾을 수 없습니다."),
-    INVALID_PERMISSION(HttpStatus.UNAUTHORIZED,"권한이 없습니다."),
+    INVALID_PERMISSION(HttpStatus.UNAUTHORIZED, "권한이 없습니다."),
 
     PLACE_NOT_FOUND(HttpStatus.NOT_FOUND, "일치하는 장소가 없습니다."),
     PLACE_DUPLICATE(HttpStatus.CONFLICT, "기존 장소와 동일합니다."),
     SCHEDULE_DATE_INVALID(HttpStatus.BAD_REQUEST, "일정 기간이 유효하지 않습니다."),
     SCHEDULE_DETAIL_DATE_INVALID(HttpStatus.BAD_REQUEST, "일정 상세 날짜가 일정 기간을 벗어났습니다."),
-    SCHEDULE_NOT_FOUND(HttpStatus.NOT_FOUND, "일치하는 일정이 없습니다."),
-
-    UNAUTHORIZED_ACCESS(HttpStatus.FORBIDDEN, "접근 권한이 없습니다.");
+    SCHEDULE_NOT_FOUND(HttpStatus.NOT_FOUND, "일치하는 일정이 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/triprecord/triprecord/schedule/controller/ScheduleController.java
+++ b/src/main/java/com/triprecord/triprecord/schedule/controller/ScheduleController.java
@@ -36,7 +36,7 @@ public class ScheduleController {
     }
 
     @PatchMapping("/{scheduleId}")
-    public ResponseEntity<ResponseMessage> updateSchedule(Authentication authentication, @PathVariable @Valid Long scheduleId, @RequestBody ScheduleUpdateRequest request) {
+    public ResponseEntity<ResponseMessage> updateSchedule(Authentication authentication, @PathVariable Long scheduleId, @RequestBody ScheduleUpdateRequest request) {
         Long userId = Long.valueOf(authentication.getName());
         scheduleService.updateSchedule(userId, scheduleId, request);
         return ResponseEntity
@@ -53,7 +53,7 @@ public class ScheduleController {
     }
 
     @DeleteMapping("/{scheduleId}")
-    public ResponseEntity<ResponseMessage> deleteSchedule(Authentication authentication, @PathVariable @Valid Long scheduleId) {
+    public ResponseEntity<ResponseMessage> deleteSchedule(Authentication authentication, @PathVariable Long scheduleId) {
         Long userId = Long.valueOf(authentication.getName());
         scheduleService.deleteSchedule(userId, scheduleId);
         return ResponseEntity

--- a/src/main/java/com/triprecord/triprecord/schedule/controller/ScheduleController.java
+++ b/src/main/java/com/triprecord/triprecord/schedule/controller/ScheduleController.java
@@ -2,14 +2,15 @@ package com.triprecord.triprecord.schedule.controller;
 
 import com.triprecord.triprecord.global.util.ResponseMessage;
 import com.triprecord.triprecord.schedule.dto.request.ScheduleCreateRequest;
-import com.triprecord.triprecord.schedule.dto.response.ScheduleGetResponse;
 import com.triprecord.triprecord.schedule.dto.request.ScheduleUpdateRequest;
+import com.triprecord.triprecord.schedule.dto.response.ScheduleGetResponse;
 import com.triprecord.triprecord.schedule.service.ScheduleService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -49,6 +50,15 @@ public class ScheduleController {
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(response);
+    }
+
+    @DeleteMapping("/{scheduleId}")
+    public ResponseEntity<ResponseMessage> deleteSchedule(Authentication authentication, @PathVariable @Valid Long scheduleId) {
+        Long userId = Long.valueOf(authentication.getName());
+        scheduleService.deleteSchedule(userId, scheduleId);
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(new ResponseMessage("일정 삭제에 성공했습니다."));
     }
 
 }

--- a/src/main/java/com/triprecord/triprecord/schedule/service/ScheduleService.java
+++ b/src/main/java/com/triprecord/triprecord/schedule/service/ScheduleService.java
@@ -98,9 +98,7 @@ public class ScheduleService {
     public void updateSchedule(Long userId, Long scheduleId, ScheduleUpdateRequest ScheduleRequest) {
         User user = userService.getUserOrException(userId);
         Schedule schedule = getScheduleOrException(scheduleId);
-        if (schedule.getCreatedUser() != user) {
-            throw new TripRecordException(ErrorCode.INVALID_PERMISSION);
-        }
+        checkSameUser(schedule.getCreatedUser(), user);
 
         schedule.updateSchedule(ScheduleRequest);
 
@@ -113,9 +111,7 @@ public class ScheduleService {
     public void deleteSchedule(Long userId, Long scheduleId) {
         User user = userService.getUserOrException(userId);
         Schedule schedule = getScheduleOrException(scheduleId);
-        if (user != schedule.getCreatedUser()) {
-            throw new TripRecordException(ErrorCode.INVALID_PERMISSION);
-        }
+        checkSameUser(schedule.getCreatedUser(), user);
 
         scheduleRepository.delete(schedule);
     }
@@ -130,6 +126,12 @@ public class ScheduleService {
         if (ScheduleRequest.scheduleDetails() == null || ScheduleRequest.scheduleDetails().isEmpty()) return;
 
         scheduleDetailService.updateScheduleDetail(schedule, ScheduleRequest);
+    }
+
+    private void checkSameUser(User createdUser, User user) {
+        if (createdUser != user) {
+            throw new TripRecordException(ErrorCode.INVALID_PERMISSION);
+        }
     }
 
 }

--- a/src/main/java/com/triprecord/triprecord/schedule/service/ScheduleService.java
+++ b/src/main/java/com/triprecord/triprecord/schedule/service/ScheduleService.java
@@ -11,9 +11,9 @@ import com.triprecord.triprecord.schedule.entity.Schedule;
 import com.triprecord.triprecord.schedule.entity.ScheduleDetail;
 import com.triprecord.triprecord.schedule.entity.SchedulePlace;
 import com.triprecord.triprecord.schedule.repository.ScheduleRepository;
-import com.triprecord.triprecord.user.service.UserService;
 import com.triprecord.triprecord.user.entity.TripStyle;
 import com.triprecord.triprecord.user.entity.User;
+import com.triprecord.triprecord.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -99,7 +99,7 @@ public class ScheduleService {
         User user = userService.getUserOrException(userId);
         Schedule schedule = getScheduleOrException(scheduleId);
         if (schedule.getCreatedUser() != user) {
-            throw new TripRecordException(ErrorCode.UNAUTHORIZED_ACCESS);
+            throw new TripRecordException(ErrorCode.INVALID_PERMISSION);
         }
 
         schedule.updateSchedule(ScheduleRequest);
@@ -107,6 +107,17 @@ public class ScheduleService {
         updateSchedulePlace(schedule, ScheduleRequest);
 
         updateScheduleDetail(schedule, ScheduleRequest);
+    }
+
+    @Transactional
+    public void deleteSchedule(Long userId, Long scheduleId) {
+        User user = userService.getUserOrException(userId);
+        Schedule schedule = getScheduleOrException(scheduleId);
+        if (user != schedule.getCreatedUser()) {
+            throw new TripRecordException(ErrorCode.INVALID_PERMISSION);
+        }
+
+        scheduleRepository.delete(schedule);
     }
 
     private void updateSchedulePlace(Schedule schedule, ScheduleUpdateRequest ScheduleRequest) {


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- feat/#26 -> dev
- close #26

## Key Changes
<!-- 최대한 자세히 -->
일정을 삭제하는 API를 구현했습니다.
Schedule 엔티티 내에는 자식 엔티티들이 Cascade.ALL 속성으로 묶여있기 때문에, 일정 엔티티가 삭제되면 해당 일정 엔티티와 관계를 맺고 있던 SchedulePlace, ScheduleDetail, ScheduleLike, ScheduleComment 엔티티가 자동으로 함께 삭제됩니다.

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->
X

## References
<!-- 참고한 자료-->
X