### PR TITLE
[FIX] 이메일 회원가입 API 여행 스타일 관련 로직 제거

### DIFF
--- a/src/main/java/com/triprecord/triprecord/user/UserController.java
+++ b/src/main/java/com/triprecord/triprecord/user/UserController.java
@@ -8,7 +8,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-
 import java.net.URI;
 import java.util.Map;
 

--- a/src/main/java/com/triprecord/triprecord/user/UserController.java
+++ b/src/main/java/com/triprecord/triprecord/user/UserController.java
@@ -1,14 +1,15 @@
 package com.triprecord.triprecord.user;
 
-import jakarta.security.auth.message.AuthException;
+import com.triprecord.triprecord.global.util.ResponseMessage;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import java.net.URI;
+
 import java.util.Map;
 
 @RestController
@@ -19,14 +20,18 @@ public class UserController {
     private final UserService userService;
 
     @PostMapping("/signup")
-    public ResponseEntity<String> signup(@RequestBody @Valid UserCreateRequest userCreateRequest) {
-        URI uri = URI.create("/users/" + userService.signup(userCreateRequest));
-        return ResponseEntity.created(uri).build();
+    public ResponseEntity<ResponseMessage> signup(@RequestBody @Valid UserCreateRequest userCreateRequest) {
+        userService.signup(userCreateRequest);
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(new ResponseMessage("회원가입에 성공했습니다."));
     }
 
     @PostMapping("/login")
     public ResponseEntity<Map<String, String>> login(@RequestBody @Valid UserLoginRequest userLoginRequest) {
         String token = userService.login(userLoginRequest);
-        return ResponseEntity.ok().body(Map.of("Authorization", token));
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(Map.of("Authorization", token));
     }
 }

--- a/src/main/java/com/triprecord/triprecord/user/UserCreateRequest.java
+++ b/src/main/java/com/triprecord/triprecord/user/UserCreateRequest.java
@@ -2,13 +2,14 @@ package com.triprecord.triprecord.user;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotNull;
+
 import java.time.LocalDate;
+
 public record UserCreateRequest(
         @Email @NotNull String userEmail,
         @NotNull String userPassword,
         @NotNull String userNickname,
         @NotNull LocalDate userAge,
-        @NotNull Long userBasicProfileId,
-        @NotNull Long userTripStyleId
+        @NotNull Long userBasicProfileId
 ) {
 }

--- a/src/main/java/com/triprecord/triprecord/user/UserService.java
+++ b/src/main/java/com/triprecord/triprecord/user/UserService.java
@@ -5,10 +5,8 @@ import com.triprecord.triprecord.global.config.jwt.JwtProvider;
 import com.triprecord.triprecord.global.config.jwt.UserAuthentication;
 import com.triprecord.triprecord.global.exception.ErrorCode;
 import com.triprecord.triprecord.global.exception.TripRecordException;
-import com.triprecord.triprecord.user.repository.TripStyleRepository;
 import com.triprecord.triprecord.user.entity.User;
 import com.triprecord.triprecord.user.repository.UserRepository;
-import jakarta.security.auth.message.AuthException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -24,7 +22,6 @@ public class UserService {
     private final JwtProvider jwtProvider;
     private final UserRepository userRepository;
     private final BasicProfileRepository basicProfileRepository;
-    private final TripStyleRepository tripStyleRepository;
     private final PasswordEncoder passwordEncoder;
 
     @Transactional
@@ -41,7 +38,6 @@ public class UserService {
                 .userAge(userCreateRequest.userAge())
                 .userProfileImg(basicProfileRepository.findById(userCreateRequest.userBasicProfileId()).get().getBasicProfileImg())
                 .userNickname(userCreateRequest.userNickname())
-                .tripStyle(tripStyleRepository.findById(userCreateRequest.userTripStyleId()).get())
                 .build();
 
         userRepository.save(newUser);


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- fix/#36 -> dev
- close #36

## Key Changes
<!-- 최대한 자세히 -->
이메일 회원가입 기능에서 유저의 여행 스타일을 선택하는 기능이 빠지게 되는 요구사항의 변경으로 이메일 회원가입 API에서 여행 스타일 관련 로직을 제거했습니다.
+ 이메일 회원가입 API의 응답값을 공통 API 응답 객체를 사용하도록 수정했고, 코드의 일관성을 위해 아래 형식으로 반환 코드를 리팩토링 했습니다.
```java
return ResponseEntity
        .status()
        .body();
``` 

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->
X

## References
<!-- 참고한 자료-->
X