### PR TITLE
[FEAT] 기록 단건 조회 API

### DIFF
--- a/src/main/java/com/triprecord/triprecord/location/PlaceBasicData.java
+++ b/src/main/java/com/triprecord/triprecord/location/PlaceBasicData.java
@@ -1,0 +1,17 @@
+package com.triprecord.triprecord.location;
+
+import com.triprecord.triprecord.location.entity.Place;
+
+public record PlaceBasicData(
+        Long placeId,
+        String countryName,
+        String placeName
+) {
+    public static PlaceBasicData fromPlace(Place place){
+        return new PlaceBasicData(
+                place.getPlaceId(),
+                place.getPlaceCountry().getCountryName(),
+                place.getPlaceName()
+        );
+    }
+}

--- a/src/main/java/com/triprecord/triprecord/record/controller/RecordController.java
+++ b/src/main/java/com/triprecord/triprecord/record/controller/RecordController.java
@@ -4,7 +4,7 @@ package com.triprecord.triprecord.record.controller;
 import com.triprecord.triprecord.global.util.ResponseMessage;
 import com.triprecord.triprecord.record.controller.request.RecordCreateRequest;
 import com.triprecord.triprecord.record.controller.request.RecordModifyRequest;
-import com.triprecord.triprecord.record.controller.response.RecordDataResponse;
+import com.triprecord.triprecord.record.controller.response.RecordResponse;
 import com.triprecord.triprecord.record.service.RecordService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -34,8 +34,8 @@ public class RecordController {
     }
 
     @GetMapping("/{recordId}")
-    public ResponseEntity<RecordDataResponse> getRecordData(@PathVariable Long recordId){
-        return ResponseEntity.status(HttpStatus.OK).body(recordService.getRecordData(recordId));
+    public ResponseEntity<RecordResponse> getRecordData(@PathVariable Long recordId){
+        return ResponseEntity.status(HttpStatus.OK).body(recordService.getRecordResponseData(recordId));
     }
 
     @DeleteMapping("/{recordId}")

--- a/src/main/java/com/triprecord/triprecord/record/controller/RecordController.java
+++ b/src/main/java/com/triprecord/triprecord/record/controller/RecordController.java
@@ -4,12 +4,14 @@ package com.triprecord.triprecord.record.controller;
 import com.triprecord.triprecord.global.util.ResponseMessage;
 import com.triprecord.triprecord.record.controller.request.RecordCreateRequest;
 import com.triprecord.triprecord.record.controller.request.RecordModifyRequest;
+import com.triprecord.triprecord.record.controller.response.RecordResponse;
 import com.triprecord.triprecord.record.service.RecordService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -29,6 +31,11 @@ public class RecordController {
     public ResponseEntity<ResponseMessage> createRecord(Authentication authentication, @Valid RecordCreateRequest request){
         recordService.createRecord(Long.valueOf(authentication.getName()), request);
         return ResponseEntity.status(HttpStatus.CREATED).body(new ResponseMessage("기록 생성에 성공했습니다."));
+    }
+
+    @GetMapping("/{recordId}")
+    public ResponseEntity<RecordResponse> record(@PathVariable Long recordId){
+        return ResponseEntity.status(HttpStatus.OK).body(recordService.getRecordData(recordId));
     }
 
     @DeleteMapping("/{recordId}")

--- a/src/main/java/com/triprecord/triprecord/record/controller/RecordController.java
+++ b/src/main/java/com/triprecord/triprecord/record/controller/RecordController.java
@@ -4,7 +4,7 @@ package com.triprecord.triprecord.record.controller;
 import com.triprecord.triprecord.global.util.ResponseMessage;
 import com.triprecord.triprecord.record.controller.request.RecordCreateRequest;
 import com.triprecord.triprecord.record.controller.request.RecordModifyRequest;
-import com.triprecord.triprecord.record.controller.response.RecordResponse;
+import com.triprecord.triprecord.record.controller.response.RecordDataResponse;
 import com.triprecord.triprecord.record.service.RecordService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -34,7 +34,7 @@ public class RecordController {
     }
 
     @GetMapping("/{recordId}")
-    public ResponseEntity<RecordResponse> record(@PathVariable Long recordId){
+    public ResponseEntity<RecordDataResponse> getRecordData(@PathVariable Long recordId){
         return ResponseEntity.status(HttpStatus.OK).body(recordService.getRecordData(recordId));
     }
 

--- a/src/main/java/com/triprecord/triprecord/record/controller/response/RecordDataResponse.java
+++ b/src/main/java/com/triprecord/triprecord/record/controller/response/RecordDataResponse.java
@@ -2,10 +2,9 @@ package com.triprecord.triprecord.record.controller.response;
 
 import com.triprecord.triprecord.record.entity.Record;
 import com.triprecord.triprecord.user.dto.response.UserProfile;
-import com.triprecord.triprecord.user.entity.User;
 import java.time.LocalDate;
 
-public record RecordResponse(
+public record RecordDataResponse(
         UserProfile recordUserProfile,
         Long recordId,
         String recordTitle,
@@ -16,8 +15,8 @@ public record RecordResponse(
         Long commentCount
 
 ) {
-    public static RecordResponse fromRecord(Record record, Long likeCount, Long commentCount){
-        return new RecordResponse(
+    public static RecordDataResponse fromRecord(Record record, Long likeCount, Long commentCount){
+        return new RecordDataResponse(
                 UserProfile.of(record.getCreatedUser()),
                 record.getRecordId(),
                 record.getRecordTitle(),

--- a/src/main/java/com/triprecord/triprecord/record/controller/response/RecordResponse.java
+++ b/src/main/java/com/triprecord/triprecord/record/controller/response/RecordResponse.java
@@ -1,0 +1,31 @@
+package com.triprecord.triprecord.record.controller.response;
+
+import com.triprecord.triprecord.record.entity.Record;
+import com.triprecord.triprecord.user.dto.response.UserProfile;
+import com.triprecord.triprecord.user.entity.User;
+import java.time.LocalDate;
+
+public record RecordResponse(
+        UserProfile recordUserProfile,
+        Long recordId,
+        String recordTitle,
+        String recordContent,
+        LocalDate tripStartDate,
+        LocalDate tripEndDate,
+        Long likeCount,
+        Long commentCount
+
+) {
+    public static RecordResponse fromRecord(Record record, Long likeCount, Long commentCount){
+        return new RecordResponse(
+                UserProfile.of(record.getCreatedUser()),
+                record.getRecordId(),
+                record.getRecordTitle(),
+                record.getRecordContent(),
+                record.getTripStartDate(),
+                record.getTripEndDate(),
+                likeCount,
+                commentCount
+        );
+    }
+}

--- a/src/main/java/com/triprecord/triprecord/record/controller/response/RecordResponse.java
+++ b/src/main/java/com/triprecord/triprecord/record/controller/response/RecordResponse.java
@@ -1,28 +1,39 @@
 package com.triprecord.triprecord.record.controller.response;
 
+import com.triprecord.triprecord.location.PlaceBasicData;
+import com.triprecord.triprecord.record.dto.RecordImageData;
 import com.triprecord.triprecord.record.entity.Record;
 import com.triprecord.triprecord.user.dto.response.UserProfile;
 import java.time.LocalDate;
+import java.util.List;
 
-public record RecordDataResponse(
+public record RecordResponse(
         UserProfile recordUserProfile,
+        List<PlaceBasicData> recordPlaces,
         Long recordId,
         String recordTitle,
         String recordContent,
         LocalDate tripStartDate,
         LocalDate tripEndDate,
+        List<RecordImageData> recordImages,
         Long likeCount,
         Long commentCount
 
 ) {
-    public static RecordDataResponse fromRecord(Record record, Long likeCount, Long commentCount){
-        return new RecordDataResponse(
+    public static RecordResponse fromRecordDatas(Record record,
+                                            List<PlaceBasicData> recordPlaces,
+                                            List<RecordImageData> images,
+                                            Long likeCount,
+                                            Long commentCount){
+        return new RecordResponse(
                 UserProfile.of(record.getCreatedUser()),
+                recordPlaces,
                 record.getRecordId(),
                 record.getRecordTitle(),
                 record.getRecordContent(),
                 record.getTripStartDate(),
                 record.getTripEndDate(),
+                images,
                 likeCount,
                 commentCount
         );

--- a/src/main/java/com/triprecord/triprecord/record/controller/response/RecordResponse.java
+++ b/src/main/java/com/triprecord/triprecord/record/controller/response/RecordResponse.java
@@ -20,11 +20,11 @@ public record RecordResponse(
         Long commentCount
 
 ) {
-    public static RecordResponse fromRecordDatas(Record record,
-                                            List<PlaceBasicData> recordPlaces,
-                                            List<RecordImageData> images,
-                                            Long likeCount,
-                                            Long commentCount){
+    public static RecordResponse fromRecordData(Record record,
+                                                List<PlaceBasicData> recordPlaces,
+                                                List<RecordImageData> images,
+                                                Long likeCount,
+                                                Long commentCount){
         return new RecordResponse(
                 UserProfile.of(record.getCreatedUser()),
                 recordPlaces,

--- a/src/main/java/com/triprecord/triprecord/record/dto/RecordImageData.java
+++ b/src/main/java/com/triprecord/triprecord/record/dto/RecordImageData.java
@@ -4,7 +4,7 @@ import com.triprecord.triprecord.record.entity.RecordImage;
 
 public record RecordImageData(
         Long recordImageId,
-        String recordImageURL
+        String recordImageUrl
 ) {
     public static RecordImageData fromImage(RecordImage recordImage){
         return new RecordImageData(

--- a/src/main/java/com/triprecord/triprecord/record/dto/RecordImageData.java
+++ b/src/main/java/com/triprecord/triprecord/record/dto/RecordImageData.java
@@ -1,0 +1,15 @@
+package com.triprecord.triprecord.record.dto;
+
+import com.triprecord.triprecord.record.entity.RecordImage;
+
+public record RecordImageData(
+        Long recordImageId,
+        String recordImageURL
+) {
+    public static RecordImageData fromImage(RecordImage recordImage){
+        return new RecordImageData(
+                recordImage.getRecordImgId(),
+                recordImage.getRecordImgUrl()
+        );
+    }
+}

--- a/src/main/java/com/triprecord/triprecord/record/repository/RecordCommentRepository.java
+++ b/src/main/java/com/triprecord/triprecord/record/repository/RecordCommentRepository.java
@@ -1,0 +1,13 @@
+package com.triprecord.triprecord.record.repository;
+
+import com.triprecord.triprecord.record.entity.Record;
+import com.triprecord.triprecord.record.entity.RecordComment;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+
+@Repository
+public interface RecordCommentRepository extends JpaRepository<RecordComment, Long> {
+
+    Long countByCommentedRecord(Record record);
+}

--- a/src/main/java/com/triprecord/triprecord/record/repository/RecordLikeRepository.java
+++ b/src/main/java/com/triprecord/triprecord/record/repository/RecordLikeRepository.java
@@ -1,5 +1,6 @@
 package com.triprecord.triprecord.record.repository;
 
+import com.triprecord.triprecord.record.entity.Record;
 import com.triprecord.triprecord.record.entity.RecordLike;
 import com.triprecord.triprecord.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -8,5 +9,6 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface RecordLikeRepository extends JpaRepository<RecordLike, Long> {
 
+    Long countByLikedRecord(Record record);
     Long countRecordLikeByLikedUser(User user);
 }

--- a/src/main/java/com/triprecord/triprecord/record/repository/RecordPlaceRepository.java
+++ b/src/main/java/com/triprecord/triprecord/record/repository/RecordPlaceRepository.java
@@ -4,6 +4,7 @@ import com.triprecord.triprecord.location.entity.Place;
 import com.triprecord.triprecord.record.entity.Record;
 import com.triprecord.triprecord.record.entity.RecordPlace;
 import com.triprecord.triprecord.user.entity.User;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -14,6 +15,10 @@ public interface RecordPlaceRepository extends JpaRepository<RecordPlace, Long> 
 
     long countByLinkedRecord(Record linkedRecord);
     void deleteByLinkedRecordAndRecordPlace(Record linkedRecord, Place recordPlace);
+
+    @Query("SELECT r.recordPlace FROM RecordPlace r WHERE r.linkedRecord = :record")
+    List<Place> findAllPlaceByLinkedRecord(Record record);
+
     @Query("select count(distinct rp.recordPlace) from RecordPlace rp where rp.linkedRecord.createdUser = :user")
     Long placeCount(@Param("user") User user);
 }

--- a/src/main/java/com/triprecord/triprecord/record/service/RecordCommentService.java
+++ b/src/main/java/com/triprecord/triprecord/record/service/RecordCommentService.java
@@ -12,7 +12,7 @@ public class RecordCommentService {
 
     private final RecordCommentRepository recordCommentRepository;
 
-    public long getRecordCommentCount(Record record){
+    public Long getRecordCommentCount(Record record){
         return recordCommentRepository.countByCommentedRecord(record);
     }
 }

--- a/src/main/java/com/triprecord/triprecord/record/service/RecordCommentService.java
+++ b/src/main/java/com/triprecord/triprecord/record/service/RecordCommentService.java
@@ -1,0 +1,18 @@
+package com.triprecord.triprecord.record.service;
+
+
+import com.triprecord.triprecord.record.entity.Record;
+import com.triprecord.triprecord.record.repository.RecordCommentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class RecordCommentService {
+
+    private final RecordCommentRepository recordCommentRepository;
+
+    public long getRecordCommentCount(Record record){
+        return recordCommentRepository.countByCommentedRecord(record);
+    }
+}

--- a/src/main/java/com/triprecord/triprecord/record/service/RecordImageService.java
+++ b/src/main/java/com/triprecord/triprecord/record/service/RecordImageService.java
@@ -3,6 +3,7 @@ package com.triprecord.triprecord.record.service;
 import com.triprecord.triprecord.global.exception.ErrorCode;
 import com.triprecord.triprecord.global.exception.TripRecordException;
 import com.triprecord.triprecord.global.util.S3Service;
+import com.triprecord.triprecord.record.dto.RecordImageData;
 import com.triprecord.triprecord.record.entity.Record;
 import com.triprecord.triprecord.record.entity.RecordImage;
 import com.triprecord.triprecord.record.repository.RecordImageRepository;
@@ -46,6 +47,12 @@ public class RecordImageService {
                     .build();
             recordImageRepository.save(recordImage);
         }
+    }
+
+    @Transactional(readOnly = true)
+    public List<RecordImageData> findRecordImageData(Record record) {
+        List<RecordImage> images =  recordImageRepository.findAllByLinkedRecord(record);
+        return images.stream().map(RecordImageData::fromImage).toList();
     }
 
     @Transactional

--- a/src/main/java/com/triprecord/triprecord/record/service/RecordLikeService.java
+++ b/src/main/java/com/triprecord/triprecord/record/service/RecordLikeService.java
@@ -12,7 +12,7 @@ public class RecordLikeService {
 
     private final RecordLikeRepository recordLikeRepository;
 
-    public long getRecordLikeCount(Record record){
+    public Long getRecordLikeCount(Record record){
         return recordLikeRepository.countByLikedRecord(record);
     }
 }

--- a/src/main/java/com/triprecord/triprecord/record/service/RecordLikeService.java
+++ b/src/main/java/com/triprecord/triprecord/record/service/RecordLikeService.java
@@ -1,0 +1,18 @@
+package com.triprecord.triprecord.record.service;
+
+
+import com.triprecord.triprecord.record.entity.Record;
+import com.triprecord.triprecord.record.repository.RecordLikeRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class RecordLikeService {
+
+    private final RecordLikeRepository recordLikeRepository;
+
+    public long getRecordLikeCount(Record record){
+        return recordLikeRepository.countByLikedRecord(record);
+    }
+}

--- a/src/main/java/com/triprecord/triprecord/record/service/RecordPlaceService.java
+++ b/src/main/java/com/triprecord/triprecord/record/service/RecordPlaceService.java
@@ -3,7 +3,7 @@ package com.triprecord.triprecord.record.service;
 
 import com.triprecord.triprecord.global.exception.ErrorCode;
 import com.triprecord.triprecord.global.exception.TripRecordException;
-import com.triprecord.triprecord.location.PlaceRepository;
+import com.triprecord.triprecord.location.PlaceBasicData;
 import com.triprecord.triprecord.location.PlaceService;
 import com.triprecord.triprecord.location.entity.Place;
 import com.triprecord.triprecord.record.entity.Record;
@@ -43,6 +43,12 @@ public class RecordPlaceService {
                     .build();
             recordPlaceRepository.save(recordPlace);
         }
+    }
+
+    @Transactional(readOnly = true)
+    public List<PlaceBasicData> getRecordPlaceBasicData(Record record) {
+        List<Place> linkedPlaceList = recordPlaceRepository.findAllPlaceByLinkedRecord(record);
+        return linkedPlaceList.stream().map(PlaceBasicData::fromPlace).toList();
     }
 
     @Transactional

--- a/src/main/java/com/triprecord/triprecord/record/service/RecordService.java
+++ b/src/main/java/com/triprecord/triprecord/record/service/RecordService.java
@@ -4,6 +4,7 @@ package com.triprecord.triprecord.record.service;
 import com.triprecord.triprecord.global.exception.ErrorCode;
 import com.triprecord.triprecord.global.exception.TripRecordException;
 import com.triprecord.triprecord.record.controller.request.RecordModifyRequest;
+import com.triprecord.triprecord.record.controller.response.RecordResponse;
 import com.triprecord.triprecord.record.dto.RecordUpdateData;
 import com.triprecord.triprecord.record.entity.Record;
 import com.triprecord.triprecord.record.repository.RecordRepository;
@@ -27,6 +28,10 @@ public class RecordService {
     private final RecordRepository recordRepository;
     private final RecordImageService recordImageService;
     private final RecordPlaceService recordPlaceService;
+    private final RecordCommentService recordCommentService;
+    private final RecordLikeService recordLikeService;
+
+
 
     @Transactional
     public void createRecord(Long userId, RecordCreateRequest request){
@@ -42,6 +47,15 @@ public class RecordService {
         recordRepository.save(record);
         recordPlaceService.createRecordPlaces(record, request.placeIds());
         recordImageService.createRecordImages(record, request.recordImages());
+    }
+
+    @Transactional(readOnly = true)
+    public RecordResponse getRecordData(Long recordId) {
+        Record record = getRecordOrException(recordId);
+        Long likeCount = recordLikeService.getRecordLikeCount(record);
+        Long commentCount = recordCommentService.getRecordCommentCount(record);
+
+        return RecordResponse.fromRecord(record, likeCount, commentCount);
     }
 
     @Transactional

--- a/src/main/java/com/triprecord/triprecord/record/service/RecordService.java
+++ b/src/main/java/com/triprecord/triprecord/record/service/RecordService.java
@@ -4,7 +4,7 @@ package com.triprecord.triprecord.record.service;
 import com.triprecord.triprecord.global.exception.ErrorCode;
 import com.triprecord.triprecord.global.exception.TripRecordException;
 import com.triprecord.triprecord.record.controller.request.RecordModifyRequest;
-import com.triprecord.triprecord.record.controller.response.RecordResponse;
+import com.triprecord.triprecord.record.controller.response.RecordDataResponse;
 import com.triprecord.triprecord.record.dto.RecordUpdateData;
 import com.triprecord.triprecord.record.entity.Record;
 import com.triprecord.triprecord.record.repository.RecordRepository;
@@ -50,12 +50,12 @@ public class RecordService {
     }
 
     @Transactional(readOnly = true)
-    public RecordResponse getRecordData(Long recordId) {
+    public RecordDataResponse getRecordData(Long recordId) {
         Record record = getRecordOrException(recordId);
         Long likeCount = recordLikeService.getRecordLikeCount(record);
         Long commentCount = recordCommentService.getRecordCommentCount(record);
 
-        return RecordResponse.fromRecord(record, likeCount, commentCount);
+        return RecordDataResponse.fromRecord(record, likeCount, commentCount);
     }
 
     @Transactional

--- a/src/main/java/com/triprecord/triprecord/record/service/RecordService.java
+++ b/src/main/java/com/triprecord/triprecord/record/service/RecordService.java
@@ -55,13 +55,13 @@ public class RecordService {
     public RecordResponse getRecordResponseData(Long recordId) {
         Record record = getRecordOrException(recordId);
 
-        List<PlaceBasicData> recordPlace = recordPlaceService.getRecordPlaceBasicData(record);
+        List<PlaceBasicData> recordPlaceData = recordPlaceService.getRecordPlaceBasicData(record);
         List<RecordImageData> recordImageData = recordImageService.findRecordImageData(record);
 
         Long likeCount = recordLikeService.getRecordLikeCount(record);
         Long commentCount = recordCommentService.getRecordCommentCount(record);
 
-        return RecordResponse.fromRecordDatas(record, recordPlace, recordImageData, likeCount, commentCount);
+        return RecordResponse.fromRecordData(record, recordPlaceData, recordImageData, likeCount, commentCount);
     }
 
     @Transactional

--- a/src/main/java/com/triprecord/triprecord/record/service/RecordService.java
+++ b/src/main/java/com/triprecord/triprecord/record/service/RecordService.java
@@ -108,7 +108,7 @@ public class RecordService {
 
     private Record getRecordOrException(Long recordId){
         return recordRepository.findByRecordId(recordId).orElseThrow(()->
-                new TripRecordException(ErrorCode.USER_NOT_FOUND));
+                new TripRecordException(ErrorCode.RECORD_NOT_FOUND));
     }
 
 }

--- a/src/main/java/com/triprecord/triprecord/record/service/RecordService.java
+++ b/src/main/java/com/triprecord/triprecord/record/service/RecordService.java
@@ -3,8 +3,10 @@ package com.triprecord.triprecord.record.service;
 
 import com.triprecord.triprecord.global.exception.ErrorCode;
 import com.triprecord.triprecord.global.exception.TripRecordException;
+import com.triprecord.triprecord.location.PlaceBasicData;
 import com.triprecord.triprecord.record.controller.request.RecordModifyRequest;
-import com.triprecord.triprecord.record.controller.response.RecordDataResponse;
+import com.triprecord.triprecord.record.controller.response.RecordResponse;
+import com.triprecord.triprecord.record.dto.RecordImageData;
 import com.triprecord.triprecord.record.dto.RecordUpdateData;
 import com.triprecord.triprecord.record.entity.Record;
 import com.triprecord.triprecord.record.repository.RecordRepository;
@@ -50,12 +52,16 @@ public class RecordService {
     }
 
     @Transactional(readOnly = true)
-    public RecordDataResponse getRecordData(Long recordId) {
+    public RecordResponse getRecordResponseData(Long recordId) {
         Record record = getRecordOrException(recordId);
+
+        List<PlaceBasicData> recordPlace = recordPlaceService.getRecordPlaceBasicData(record);
+        List<RecordImageData> recordImageData = recordImageService.findRecordImageData(record);
+
         Long likeCount = recordLikeService.getRecordLikeCount(record);
         Long commentCount = recordCommentService.getRecordCommentCount(record);
 
-        return RecordDataResponse.fromRecord(record, likeCount, commentCount);
+        return RecordResponse.fromRecordDatas(record, recordPlace, recordImageData, likeCount, commentCount);
     }
 
     @Transactional


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- feat/#44 -> dev
- close #44

## Key Changes
<!-- 최대한 자세히 -->
### 기록 단건을 조회하는 API 구현
- GET /records/{recordId}
- recordId와 일치하는 Record를 찾습니다.
- 요구사항에 맞춰 가공된 데이터를 반환합니다.

### 성공시의 응답 데이터 예시
![image](https://github.com/Trip-Record/Server/assets/105481797/cda8c979-1a48-4ff2-8ea1-4281d0a991d5)


### 기능 개발 외 수정사항
- recordId와 일치하는 record가 없는 경우의 에러메시지 수정


## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->
### 장소 정보 관련
현재 Response에 포함되는 장소 정보를 userprofile처럼 전역으로 사용할 수 있다고 생각해, 
Place패키지에 PlaceBasicData라는 이름의 DTO를 생성해 구현했습니다.
Place->PlaceBasicData로 변환이 가능하고, 스케쥴 장소와 레코드 장소 엔티티가 달라서 변환 메서드를 두개 만드는 경우도 생각했었지만 각 장소 정보를 List로 받아올 때, 쿼리문을 작성해 Place로 받아와 하나의 메서드만 사용하면 될 것 같습니다.
글만 읽으면 이해가 잘 안될수도 있는데 Place관련 코드 확인하시면 이해가 편할 것이라고 생각합니다!
### 그 외
사용자 접근 권한 요구사항은 #50  의 내용을 이후 merge할 예정입니다 !


조언이나 궁금한점 개선할점 등등 편하게 의견 주세요! 🙇‍♀️

## References
<!-- 참고한 자료-->
카운트 값을 long으로 받을지 Long으로 받는지 고민돼서 찾아본 내용입니다 ㅎㅎ
https://html6.tistory.com/1065
jpa의 count는 Long으로 return되긴 하지만 서비스 층에서 long으로 바꾸는 방식을 생각해서 찾아봤습니다.
