### PR TITLE
[FIX] 일정 단건 조회 API User TripStyle 관련 예외 처리 추가

### DIFF
--- a/src/main/java/com/triprecord/triprecord/schedule/dto/response/ScheduleGetResponse.java
+++ b/src/main/java/com/triprecord/triprecord/schedule/dto/response/ScheduleGetResponse.java
@@ -4,7 +4,6 @@ import com.triprecord.triprecord.schedule.entity.Schedule;
 import com.triprecord.triprecord.schedule.entity.ScheduleDetail;
 import com.triprecord.triprecord.schedule.entity.SchedulePlace;
 import com.triprecord.triprecord.user.dto.response.UserProfile;
-import com.triprecord.triprecord.user.entity.TripStyle;
 import com.triprecord.triprecord.user.entity.User;
 
 import java.util.List;
@@ -21,7 +20,6 @@ public record ScheduleGetResponse(
         Long scheduleCommentCount
 ) {
     public static ScheduleGetResponse of(User user,
-                                         TripStyle userTripStyle,
                                          Schedule schedule,
                                          List<SchedulePlace> schedulePlaces,
                                          List<ScheduleDetail> scheduleDetails,

--- a/src/main/java/com/triprecord/triprecord/schedule/service/ScheduleService.java
+++ b/src/main/java/com/triprecord/triprecord/schedule/service/ScheduleService.java
@@ -11,7 +11,6 @@ import com.triprecord.triprecord.schedule.entity.Schedule;
 import com.triprecord.triprecord.schedule.entity.ScheduleDetail;
 import com.triprecord.triprecord.schedule.entity.SchedulePlace;
 import com.triprecord.triprecord.schedule.repository.ScheduleRepository;
-import com.triprecord.triprecord.user.entity.TripStyle;
 import com.triprecord.triprecord.user.entity.User;
 import com.triprecord.triprecord.user.service.UserService;
 import lombok.RequiredArgsConstructor;
@@ -74,7 +73,6 @@ public class ScheduleService {
     public ScheduleGetResponse getSchedule(Long scheduleId) {
         Schedule schedule = getScheduleOrException(scheduleId);
         User createdUser = schedule.getCreatedUser();
-        TripStyle createdUserTripStyle = schedule.getCreatedUser().getUserTripStyle();
         List<SchedulePlace> schedulePlaces = schedule.getSchedulePlaces();
 
         List<ScheduleDetail> scheduleDetails = schedule.getScheduleDetails();
@@ -85,7 +83,6 @@ public class ScheduleService {
 
         return ScheduleGetResponse.of(
                 createdUser,
-                createdUserTripStyle,
                 schedule,
                 schedulePlaces,
                 scheduleDetails,

--- a/src/main/java/com/triprecord/triprecord/user/dto/response/UserProfile.java
+++ b/src/main/java/com/triprecord/triprecord/user/dto/response/UserProfile.java
@@ -12,8 +12,8 @@ public record UserProfile(
         return new UserProfile(
                 user.getUserNickname(),
                 user.getUserProfileImg(),
-                user.getUserTripStyle().getTripStyleName(),
-                user.getUserTripStyle().getTripStyleImg()
+                user.getUserTripStyle() == null ? null : user.getUserTripStyle().getTripStyleName(),
+                user.getUserTripStyle() == null ? null : user.getUserTripStyle().getTripStyleImg()
         );
     }
 }


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- fix/#57 -> dev
- close #57

## Key Changes
<!-- 최대한 자세히 -->
일정 단건 조회 API 응답값에 포함된 User의 TripStyle 값이 null일 경우 API 반환값이 오지 않는 오류를 발견하여,
UserProfile DTO 내에 TripStyle 값이 null일 경우 예외처리를 추가해서 오류를 해결했습니다.

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->
X

## References
<!-- 참고한 자료-->
X