### PR TITLE
[FEAT] 여행지 장소 조회 API

### DIFF
--- a/src/main/java/com/triprecord/triprecord/global/config/SecurityConfig.java
+++ b/src/main/java/com/triprecord/triprecord/global/config/SecurityConfig.java
@@ -37,6 +37,7 @@ public class SecurityConfig {
             "/schedules/{scheduleId}",
             "/schedules/{scheduleId}/comments",
             "/trip-styles"
+            ,"/locations"
     };
 
     @Bean

--- a/src/main/java/com/triprecord/triprecord/location/PlaceService.java
+++ b/src/main/java/com/triprecord/triprecord/location/PlaceService.java
@@ -2,7 +2,15 @@ package com.triprecord.triprecord.location;
 
 import com.triprecord.triprecord.global.exception.ErrorCode;
 import com.triprecord.triprecord.global.exception.TripRecordException;
+import com.triprecord.triprecord.location.dto.LocationInfoGetResponse;
+import com.triprecord.triprecord.location.entity.Continent;
+import com.triprecord.triprecord.location.entity.Country;
 import com.triprecord.triprecord.location.entity.Place;
+import com.triprecord.triprecord.location.repository.ContinentRepository;
+import com.triprecord.triprecord.location.repository.CountryRepository;
+import com.triprecord.triprecord.location.repository.PlaceRepository;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -10,9 +18,28 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class PlaceService {
     private final PlaceRepository placeRepository;
+    private final ContinentRepository continentRepository;
+    private final CountryRepository countryRepository;
 
     public Place getPlaceOrException(Long placeId) {
         return placeRepository.findByPlaceId(placeId).orElseThrow(() ->
                 new TripRecordException(ErrorCode.PLACE_NOT_FOUND));
+    }
+
+    public List<LocationInfoGetResponse> getLocationInfo(){
+
+        List<Continent> continentList = continentRepository.findAll();
+
+        List<LocationInfoGetResponse> locationInfoGetResponseList = new ArrayList<>();
+
+        for(Continent continent : continentList){
+            List<Country> countryList = countryRepository.findCountryByContinent(continent);
+            for(Country country : countryList){
+                List<Place> placeList = placeRepository.findPlaceByPlaceCountry(country);
+                locationInfoGetResponseList.add(LocationInfoGetResponse.of(continent, placeList));
+            }
+        }
+
+        return locationInfoGetResponseList;
     }
 }

--- a/src/main/java/com/triprecord/triprecord/location/PlaceService.java
+++ b/src/main/java/com/triprecord/triprecord/location/PlaceService.java
@@ -35,7 +35,7 @@ public class PlaceService {
         for(Continent continent : continentList){
             List<Country> countryList = countryRepository.findCountryByContinent(continent);
             for(Country country : countryList){
-                List<Place> placeList = placeRepository.findPlaceByPlaceCountry(country);
+                List<Place> placeList = placeRepository.findAllByPlaceCountry(country);
                 locationInfoGetResponseList.add(LocationInfoGetResponse.of(continent, placeList));
             }
         }

--- a/src/main/java/com/triprecord/triprecord/location/PlaceService.java
+++ b/src/main/java/com/triprecord/triprecord/location/PlaceService.java
@@ -33,7 +33,7 @@ public class PlaceService {
         List<LocationInfoGetResponse> locationInfoGetResponseList = new ArrayList<>();
 
         for(Continent continent : continentList){
-            List<Country> countryList = countryRepository.findCountryByContinent(continent);
+            List<Country> countryList = countryRepository.findALLByContinent(continent);
             for(Country country : countryList){
                 List<Place> placeList = placeRepository.findAllByPlaceCountry(country);
                 locationInfoGetResponseList.add(LocationInfoGetResponse.of(continent, placeList));

--- a/src/main/java/com/triprecord/triprecord/location/controller/LocationController.java
+++ b/src/main/java/com/triprecord/triprecord/location/controller/LocationController.java
@@ -1,0 +1,23 @@
+package com.triprecord.triprecord.location.controller;
+
+import com.triprecord.triprecord.location.PlaceService;
+import com.triprecord.triprecord.location.dto.LocationInfoGetResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/locations")
+public class LocationController {
+
+    private final PlaceService placeService;
+
+    @GetMapping
+    public ResponseEntity<List<LocationInfoGetResponse>> locationInfo(){
+        return ResponseEntity.ok().body(placeService.getLocationInfo());
+    }
+}

--- a/src/main/java/com/triprecord/triprecord/location/controller/LocationController.java
+++ b/src/main/java/com/triprecord/triprecord/location/controller/LocationController.java
@@ -3,6 +3,7 @@ package com.triprecord.triprecord.location.controller;
 import com.triprecord.triprecord.location.PlaceService;
 import com.triprecord.triprecord.location.dto.LocationInfoGetResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -18,6 +19,6 @@ public class LocationController {
 
     @GetMapping
     public ResponseEntity<List<LocationInfoGetResponse>> locationInfo(){
-        return ResponseEntity.ok().body(placeService.getLocationInfo());
+        return ResponseEntity.status(HttpStatus.OK).body(placeService.getLocationInfo());
     }
 }

--- a/src/main/java/com/triprecord/triprecord/location/dto/LocationInfoGetResponse.java
+++ b/src/main/java/com/triprecord/triprecord/location/dto/LocationInfoGetResponse.java
@@ -1,0 +1,21 @@
+package com.triprecord.triprecord.location.dto;
+
+import com.triprecord.triprecord.location.entity.Continent;
+import com.triprecord.triprecord.location.entity.Place;
+
+import java.util.List;
+
+public record LocationInfoGetResponse(
+        String continentName,
+        List<PlaceBasicData> placeBasicDataList
+
+) {
+    public static LocationInfoGetResponse of(Continent continent,List<Place> placeList){
+        return new LocationInfoGetResponse(
+                continent.getContinentName(),
+                placeList.stream()
+                        .map(PlaceBasicData::fromPlace)
+                        .toList()
+        );
+    }
+}

--- a/src/main/java/com/triprecord/triprecord/location/dto/PlaceBasicData.java
+++ b/src/main/java/com/triprecord/triprecord/location/dto/PlaceBasicData.java
@@ -1,4 +1,4 @@
-package com.triprecord.triprecord.location;
+package com.triprecord.triprecord.location.dto;
 
 import com.triprecord.triprecord.location.entity.Place;
 

--- a/src/main/java/com/triprecord/triprecord/location/repository/ContinentRepository.java
+++ b/src/main/java/com/triprecord/triprecord/location/repository/ContinentRepository.java
@@ -8,6 +8,4 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ContinentRepository extends JpaRepository<Continent, Long> {
-    List<Continent> findAll();
-
 }

--- a/src/main/java/com/triprecord/triprecord/location/repository/ContinentRepository.java
+++ b/src/main/java/com/triprecord/triprecord/location/repository/ContinentRepository.java
@@ -1,0 +1,13 @@
+package com.triprecord.triprecord.location.repository;
+
+import com.triprecord.triprecord.location.entity.Continent;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ContinentRepository extends JpaRepository<Continent, Long> {
+    List<Continent> findAll();
+
+}

--- a/src/main/java/com/triprecord/triprecord/location/repository/CountryRepository.java
+++ b/src/main/java/com/triprecord/triprecord/location/repository/CountryRepository.java
@@ -9,5 +9,5 @@ import java.util.List;
 
 @Repository
 public interface CountryRepository extends JpaRepository<Country, Long> {
-    List<Country> findCountryByContinent(Continent continent);
+    List<Country> findALLByContinent(Continent continent);
 }

--- a/src/main/java/com/triprecord/triprecord/location/repository/CountryRepository.java
+++ b/src/main/java/com/triprecord/triprecord/location/repository/CountryRepository.java
@@ -1,0 +1,13 @@
+package com.triprecord.triprecord.location.repository;
+
+import com.triprecord.triprecord.location.entity.Continent;
+import com.triprecord.triprecord.location.entity.Country;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface CountryRepository extends JpaRepository<Country, Long> {
+    List<Country> findCountryByContinent(Continent continent);
+}

--- a/src/main/java/com/triprecord/triprecord/location/repository/PlaceRepository.java
+++ b/src/main/java/com/triprecord/triprecord/location/repository/PlaceRepository.java
@@ -1,13 +1,16 @@
-package com.triprecord.triprecord.location;
+package com.triprecord.triprecord.location.repository;
 
 
+import com.triprecord.triprecord.location.entity.Country;
 import com.triprecord.triprecord.location.entity.Place;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
+import java.util.List;
 
 @Repository
 public interface PlaceRepository extends JpaRepository<Place, Long> {
     Optional<Place> findByPlaceId(Long placeId);
+    List<Place> findPlaceByPlaceCountry(Country country);
 }

--- a/src/main/java/com/triprecord/triprecord/location/repository/PlaceRepository.java
+++ b/src/main/java/com/triprecord/triprecord/location/repository/PlaceRepository.java
@@ -12,5 +12,5 @@ import java.util.List;
 @Repository
 public interface PlaceRepository extends JpaRepository<Place, Long> {
     Optional<Place> findByPlaceId(Long placeId);
-    List<Place> findPlaceByPlaceCountry(Country country);
+    List<Place> findAllByPlaceCountry(Country country);
 }

--- a/src/main/java/com/triprecord/triprecord/record/controller/response/RecordResponse.java
+++ b/src/main/java/com/triprecord/triprecord/record/controller/response/RecordResponse.java
@@ -1,6 +1,6 @@
 package com.triprecord.triprecord.record.controller.response;
 
-import com.triprecord.triprecord.location.PlaceBasicData;
+import com.triprecord.triprecord.location.dto.PlaceBasicData;
 import com.triprecord.triprecord.record.dto.RecordImageData;
 import com.triprecord.triprecord.record.entity.Record;
 import com.triprecord.triprecord.user.dto.response.UserProfile;

--- a/src/main/java/com/triprecord/triprecord/record/service/RecordPlaceService.java
+++ b/src/main/java/com/triprecord/triprecord/record/service/RecordPlaceService.java
@@ -3,7 +3,7 @@ package com.triprecord.triprecord.record.service;
 
 import com.triprecord.triprecord.global.exception.ErrorCode;
 import com.triprecord.triprecord.global.exception.TripRecordException;
-import com.triprecord.triprecord.location.PlaceBasicData;
+import com.triprecord.triprecord.location.dto.PlaceBasicData;
 import com.triprecord.triprecord.location.PlaceService;
 import com.triprecord.triprecord.location.entity.Place;
 import com.triprecord.triprecord.record.entity.Record;

--- a/src/main/java/com/triprecord/triprecord/record/service/RecordService.java
+++ b/src/main/java/com/triprecord/triprecord/record/service/RecordService.java
@@ -3,7 +3,7 @@ package com.triprecord.triprecord.record.service;
 
 import com.triprecord.triprecord.global.exception.ErrorCode;
 import com.triprecord.triprecord.global.exception.TripRecordException;
-import com.triprecord.triprecord.location.PlaceBasicData;
+import com.triprecord.triprecord.location.dto.PlaceBasicData;
 import com.triprecord.triprecord.record.controller.request.RecordModifyRequest;
 import com.triprecord.triprecord.record.controller.response.RecordResponse;
 import com.triprecord.triprecord.record.dto.RecordImageData;


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- feat/#56 -> dev
- close #56

## Key Changes
<!-- 최대한 자세히 -->
유저가 기록이나 일정을 기록 할 때 여행 장소를 선택하기 위해 데이터를 불러오는 API 입니다.
LocationInfoResponse에 대륙명과 PlaceBasicData(나라명, 지역명) dto를 리스트로 넣어 만들었습니다.
## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->
여행 지역에 대한 모든 정보를 불러오는 것이기 때문에 LocationController를 하나 만들었습니다. 하지만 service 는 PlaceService에 구현하였기 때문에 그냥 PlaceController에 구현하는 것이 맞는지 고민이 됩니다! 의견 있으시면 말씀해주세요!
현재 DB에 대륙명중 아시아/증동으로 오타가 난 것이 있는데, 중동으로 바로 수정하겠습니다. 현재 오타는 감안하고 봐주세요..!
![image](https://github.com/Trip-Record/Server/assets/126096318/9075af2b-e983-402c-9540-48bb4a422532)
![image](https://github.com/Trip-Record/Server/assets/126096318/8b55756d-df87-4b92-91ab-b87948e6cac9)

## References
<!-- 참고한 자료-->
