### PR TITLE
[FEAT] 기록 목록 조회 API

### DIFF
--- a/src/main/java/com/triprecord/triprecord/record/controller/RecordController.java
+++ b/src/main/java/com/triprecord/triprecord/record/controller/RecordController.java
@@ -4,10 +4,12 @@ package com.triprecord.triprecord.record.controller;
 import com.triprecord.triprecord.global.util.ResponseMessage;
 import com.triprecord.triprecord.record.controller.request.RecordCreateRequest;
 import com.triprecord.triprecord.record.controller.request.RecordModifyRequest;
+import com.triprecord.triprecord.record.controller.response.RecordPageResponse;
 import com.triprecord.triprecord.record.controller.response.RecordResponse;
 import com.triprecord.triprecord.record.service.RecordService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
@@ -31,6 +33,11 @@ public class RecordController {
     public ResponseEntity<ResponseMessage> createRecord(Authentication authentication, @Valid RecordCreateRequest request){
         recordService.createRecord(Long.valueOf(authentication.getName()), request);
         return ResponseEntity.status(HttpStatus.CREATED).body(new ResponseMessage("기록 생성에 성공했습니다."));
+    }
+
+    @GetMapping()
+    public ResponseEntity<RecordPageResponse> getRecordPage(Pageable pageable) {
+        return ResponseEntity.status(HttpStatus.OK).body(recordService.getRecordPage(pageable));
     }
 
     @GetMapping("/{recordId}")

--- a/src/main/java/com/triprecord/triprecord/record/controller/response/RecordPageResponse.java
+++ b/src/main/java/com/triprecord/triprecord/record/controller/response/RecordPageResponse.java
@@ -1,0 +1,12 @@
+package com.triprecord.triprecord.record.controller.response;
+
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record RecordPageResponse(
+        int totalPages,
+        int pageNumber,
+        List<RecordResponse> recordList
+) {
+}

--- a/src/main/java/com/triprecord/triprecord/record/repository/RecordRepository.java
+++ b/src/main/java/com/triprecord/triprecord/record/repository/RecordRepository.java
@@ -4,6 +4,8 @@ package com.triprecord.triprecord.record.repository;
 import com.triprecord.triprecord.record.entity.Record;
 import com.triprecord.triprecord.user.entity.User;
 import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -15,4 +17,7 @@ public interface RecordRepository extends JpaRepository<Record, Long> {
     Long countRecordByCreatedUser(User user);
 
     Optional<Record> findByRecordId(Long recordId);
+
+    @Query("SELECT r FROM Record r ORDER BY r.recordId DESC ")
+    Page<Record> findAllOrderById(Pageable pageable);
 }

--- a/src/main/java/com/triprecord/triprecord/record/service/RecordService.java
+++ b/src/main/java/com/triprecord/triprecord/record/service/RecordService.java
@@ -64,7 +64,7 @@ public class RecordService {
         }
         return RecordPageResponse.builder()
                 .totalPages(records.getTotalPages())
-                .pageNumber(records.getNumber()+1)
+                .pageNumber(records.getNumber())
                 .recordList(recordResponses)
                 .build();
     }

--- a/src/main/java/com/triprecord/triprecord/record/service/RecordService.java
+++ b/src/main/java/com/triprecord/triprecord/record/service/RecordService.java
@@ -5,6 +5,7 @@ import com.triprecord.triprecord.global.exception.ErrorCode;
 import com.triprecord.triprecord.global.exception.TripRecordException;
 import com.triprecord.triprecord.location.dto.PlaceBasicData;
 import com.triprecord.triprecord.record.controller.request.RecordModifyRequest;
+import com.triprecord.triprecord.record.controller.response.RecordPageResponse;
 import com.triprecord.triprecord.record.controller.response.RecordResponse;
 import com.triprecord.triprecord.record.dto.RecordImageData;
 import com.triprecord.triprecord.record.dto.RecordUpdateData;
@@ -14,9 +15,12 @@ import com.triprecord.triprecord.record.controller.request.RecordCreateRequest;
 import com.triprecord.triprecord.user.service.UserService;
 import com.triprecord.triprecord.user.entity.User;
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -49,6 +53,20 @@ public class RecordService {
         recordRepository.save(record);
         recordPlaceService.createRecordPlaces(record, request.placeIds());
         recordImageService.createRecordImages(record, request.recordImages());
+    }
+
+    @Transactional(readOnly = true)
+    public RecordPageResponse getRecordPage(Pageable pageable) {
+        Page<Record> records = recordRepository.findAllOrderById(pageable);
+        List<RecordResponse> recordResponses = new ArrayList<>();
+        for(Record record : records.getContent()) {
+            recordResponses.add(getRecordResponseData(record.getRecordId()));
+        }
+        return RecordPageResponse.builder()
+                .totalPages(records.getTotalPages())
+                .pageNumber(records.getNumber()+1)
+                .recordList(recordResponses)
+                .build();
     }
 
     @Transactional(readOnly = true)


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- feat/#59 -> dev
- close #59 

## Key Changes
<!-- 최대한 자세히 -->
### 기록 목록을 조회하는 API 개발
- /records
- 응답 데이터는 최신 순으로 정렬
- Page데이터를 담을 DTO 생성

**응답 성공시 (200)**

![image](https://github.com/Trip-Record/Server/assets/105481797/4af7ecd7-5d8a-4475-97c6-b8985fcd8bd3)
- totalPages : 총 페이지 수
- pageNumber : 현재 페이지
- recordList : 레코드

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->
PageData 작성시, 현재 페이지가 원래는 0부터 시작해서 (ex. total이 4일때 0~3이 페이지)
1부터 시작해주기 위해 +1 코드를 작성했는데, 0부터 하는게 덜 헷갈릴까요?

궁금한점, 조언 등 편하게 부탁드립니다! 😃

## References
<!-- 참고한 자료-->
