### PR TITLE
[FEAT] 기록 좋아요 취소 API

### DIFF
--- a/src/main/java/com/triprecord/triprecord/global/exception/ErrorCode.java
+++ b/src/main/java/com/triprecord/triprecord/global/exception/ErrorCode.java
@@ -20,6 +20,7 @@ public enum ErrorCode {
     INVALID_PERMISSION(HttpStatus.UNAUTHORIZED, "권한이 존재하지 않습니다."),
 
     RECORD_ALREADY_LIKED(HttpStatus.CONFLICT, "이미 좋아요를 남긴 기록입니다."),
+    RECORD_LIKE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 기록에 좋아요를 남기지 않았습니다."),
     INVALID_DATE(HttpStatus.BAD_REQUEST, "기간이 잘못되었습니다."),
     INVALID_RECORD_PLACE_SIZE(HttpStatus.BAD_REQUEST, "기록할 수 있는 최대 장소 수를 초과하였습니다."),
     INVALID_RECORD_IMAGE_SIZE(HttpStatus.BAD_REQUEST, "기록할 수 있는 최대 사진 수를 초과하였습니다."),

--- a/src/main/java/com/triprecord/triprecord/record/controller/RecordController.java
+++ b/src/main/java/com/triprecord/triprecord/record/controller/RecordController.java
@@ -58,4 +58,10 @@ public class RecordController {
         return ResponseEntity.status(HttpStatus.CREATED).body(new ResponseMessage("좋아요 전송에 성공했습니다."));
     }
 
+    @DeleteMapping("/{recordId}/likes")
+    public ResponseEntity<ResponseMessage> cancelLike(Authentication authentication, @PathVariable Long recordId) {
+        recordService.cancelLikeToRecord(Long.valueOf(authentication.getName()), recordId);
+        return ResponseEntity.status(HttpStatus.OK).body(new ResponseMessage("좋아요 취소에 성공했습니다."));
+    }
+
 }

--- a/src/main/java/com/triprecord/triprecord/record/service/RecordLikeService.java
+++ b/src/main/java/com/triprecord/triprecord/record/service/RecordLikeService.java
@@ -35,4 +35,11 @@ public class RecordLikeService {
         recordLikeRepository.save(recordLike);
     }
 
+    @Transactional
+    public void deleteRecordLike(User user, Record record) {
+        RecordLike like = recordLikeRepository.findByLikedRecordAndLikedUser(record, user).orElseThrow(()->
+                new TripRecordException(ErrorCode.RECORD_LIKE_NOT_FOUND));
+        recordLikeRepository.delete(like);
+    }
+
 }

--- a/src/main/java/com/triprecord/triprecord/record/service/RecordService.java
+++ b/src/main/java/com/triprecord/triprecord/record/service/RecordService.java
@@ -93,6 +93,12 @@ public class RecordService {
         recordLikeService.createRecordLike(user, record);
     }
 
+    public void cancelLikeToRecord(Long userId, Long recordId) {
+        User user  = userService.getUserOrException(userId);
+        Record record = getRecordOrException(recordId);
+        recordLikeService.deleteRecordLike(user, record);
+    }
+
     private void checkSameUser(User createdUser, User user){
         if(createdUser != user) throw new TripRecordException(ErrorCode.INVALID_PERMISSION);
     }


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- feat/#65 -> dev
- close #65

## Key Changes
<!-- 최대한 자세히 -->
### 인증 유저가 해당 기록에 남긴 좋아요를 취소하는 API
- /records/{recordId}/likes


**취소 성공시 (200)**

![image](https://github.com/Trip-Record/Server/assets/105481797/24a1cb85-e3b9-4cae-96e8-374a6bd995c2)

**좋아요를 누른 기록이 없을 시 (404)**

![image](https://github.com/Trip-Record/Server/assets/105481797/644fe59b-a6a6-49c2-906f-7b60d8d4091d)

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->
- 실패시의 에러코드를 좋아요 기록을 찾을 수 없다는 의미의 404 에러로 했는데,
Bad Request 여도 될 것 같기도 해서 이에 대한 의견을 듣고 싶습니다!

궁금한 점, 개선할 점 등 편하게 의견 주세요! 🙇‍♀️
## References
<!-- 참고한 자료-->
