### PR TITLE
[FEAT] 일정 목록 조회 API

### DIFF
--- a/src/main/java/com/triprecord/triprecord/schedule/controller/ScheduleController.java
+++ b/src/main/java/com/triprecord/triprecord/schedule/controller/ScheduleController.java
@@ -50,7 +50,7 @@ public class ScheduleController {
     }
 
     @GetMapping
-    public ResponseEntity<SchedulePageGetResponse> getSchedules(@PageableDefault Pageable pageable) {
+    public ResponseEntity<SchedulePageGetResponse> getSchedules(@PageableDefault(size = 5) Pageable pageable) {
         SchedulePageGetResponse response = scheduleService.getSchedules(pageable);
         return ResponseEntity
                 .status(HttpStatus.OK)

--- a/src/main/java/com/triprecord/triprecord/schedule/controller/ScheduleController.java
+++ b/src/main/java/com/triprecord/triprecord/schedule/controller/ScheduleController.java
@@ -4,9 +4,12 @@ import com.triprecord.triprecord.global.util.ResponseMessage;
 import com.triprecord.triprecord.schedule.dto.request.ScheduleCreateRequest;
 import com.triprecord.triprecord.schedule.dto.request.ScheduleUpdateRequest;
 import com.triprecord.triprecord.schedule.dto.response.ScheduleGetResponse;
+import com.triprecord.triprecord.schedule.dto.response.SchedulePageGetResponse;
 import com.triprecord.triprecord.schedule.service.ScheduleService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
@@ -27,7 +30,8 @@ public class ScheduleController {
     private final ScheduleService scheduleService;
 
     @PostMapping
-    public ResponseEntity<ResponseMessage> createSchedule(Authentication authentication, @RequestBody @Valid ScheduleCreateRequest request) {
+    public ResponseEntity<ResponseMessage> createSchedule(Authentication authentication,
+                                                          @RequestBody @Valid ScheduleCreateRequest request) {
         Long userId = Long.valueOf(authentication.getName());
         scheduleService.createSchedule(userId, request);
         return ResponseEntity
@@ -36,12 +40,21 @@ public class ScheduleController {
     }
 
     @PatchMapping("/{scheduleId}")
-    public ResponseEntity<ResponseMessage> updateSchedule(Authentication authentication, @PathVariable Long scheduleId, @RequestBody ScheduleUpdateRequest request) {
+    public ResponseEntity<ResponseMessage> updateSchedule(Authentication authentication, @PathVariable Long scheduleId,
+                                                          @RequestBody ScheduleUpdateRequest request) {
         Long userId = Long.valueOf(authentication.getName());
         scheduleService.updateSchedule(userId, scheduleId, request);
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(new ResponseMessage("일정 수정에 성공했습니다."));
+    }
+
+    @GetMapping
+    public ResponseEntity<SchedulePageGetResponse> getSchedules(@PageableDefault Pageable pageable) {
+        SchedulePageGetResponse response = scheduleService.getSchedules(pageable);
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(response);
     }
 
     @GetMapping("/{scheduleId}")
@@ -53,7 +66,8 @@ public class ScheduleController {
     }
 
     @DeleteMapping("/{scheduleId}")
-    public ResponseEntity<ResponseMessage> deleteSchedule(Authentication authentication, @PathVariable Long scheduleId) {
+    public ResponseEntity<ResponseMessage> deleteSchedule(Authentication authentication,
+                                                          @PathVariable Long scheduleId) {
         Long userId = Long.valueOf(authentication.getName());
         scheduleService.deleteSchedule(userId, scheduleId);
         return ResponseEntity

--- a/src/main/java/com/triprecord/triprecord/schedule/dto/response/SchedulePageGetResponse.java
+++ b/src/main/java/com/triprecord/triprecord/schedule/dto/response/SchedulePageGetResponse.java
@@ -1,0 +1,12 @@
+package com.triprecord.triprecord.schedule.dto.response;
+
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record SchedulePageGetResponse(
+        int totalPages,
+        int pageNumber,
+        List<ScheduleGetResponse> schedules
+) {
+}

--- a/src/main/java/com/triprecord/triprecord/schedule/repository/ScheduleRepository.java
+++ b/src/main/java/com/triprecord/triprecord/schedule/repository/ScheduleRepository.java
@@ -2,13 +2,17 @@ package com.triprecord.triprecord.schedule.repository;
 
 import com.triprecord.triprecord.schedule.entity.Schedule;
 import com.triprecord.triprecord.user.entity.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
 
     Long countScheduleByCreatedUser(User user);
+
+    @Query("SELECT s FROM Schedule s ORDER BY s.scheduleId DESC")
+    Page<Schedule> findAllOrderById(Pageable pageable);
 }

--- a/src/main/java/com/triprecord/triprecord/schedule/service/ScheduleService.java
+++ b/src/main/java/com/triprecord/triprecord/schedule/service/ScheduleService.java
@@ -7,20 +7,22 @@ import com.triprecord.triprecord.location.entity.Place;
 import com.triprecord.triprecord.schedule.dto.request.ScheduleCreateRequest;
 import com.triprecord.triprecord.schedule.dto.request.ScheduleUpdateRequest;
 import com.triprecord.triprecord.schedule.dto.response.ScheduleGetResponse;
+import com.triprecord.triprecord.schedule.dto.response.SchedulePageGetResponse;
 import com.triprecord.triprecord.schedule.entity.Schedule;
 import com.triprecord.triprecord.schedule.entity.ScheduleDetail;
 import com.triprecord.triprecord.schedule.entity.SchedulePlace;
 import com.triprecord.triprecord.schedule.repository.ScheduleRepository;
 import com.triprecord.triprecord.user.entity.User;
 import com.triprecord.triprecord.user.service.UserService;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -64,10 +66,37 @@ public class ScheduleService {
         places.stream()
                 .forEach(place -> schedulePlaceService.createSchedulePlace(schedule, place));
 
-        if (request.scheduleDetails().isEmpty()) return;
+        if (request.scheduleDetails().isEmpty()) {
+            return;
+        }
 
         request.scheduleDetails().stream()
-                .forEach(scheduleDetail -> scheduleDetailService.createScheduleDetail(schedule, scheduleDetail.scheduleDetailDate(), scheduleDetail.scheduleDetailContent()));
+                .forEach(scheduleDetail -> scheduleDetailService.createScheduleDetail(schedule,
+                        scheduleDetail.scheduleDetailDate(), scheduleDetail.scheduleDetailContent()));
+    }
+
+    public SchedulePageGetResponse getSchedules(Pageable pageable) {
+        Page<Schedule> schedules = scheduleRepository.findAllOrderById(pageable);
+        List<ScheduleGetResponse> scheduleGetResponses = new ArrayList<>();
+
+        for (Schedule schedule : schedules.getContent()) {
+            long scheduleLikeCount = scheduleLikeService.getScheduleLikeCount(schedule);
+            long scheduleCommentCount = scheduleCommentService.getScheduleCommentCount(schedule);
+            scheduleGetResponses.add(ScheduleGetResponse.of(
+                    schedule.getCreatedUser(),
+                    schedule,
+                    schedule.getSchedulePlaces(),
+                    schedule.getScheduleDetails(),
+                    scheduleLikeCount,
+                    scheduleCommentCount
+            ));
+        }
+
+        return SchedulePageGetResponse.builder()
+                .totalPages(schedules.getTotalPages())
+                .pageNumber(schedules.getNumber())
+                .schedules(scheduleGetResponses)
+                .build();
     }
 
     public ScheduleGetResponse getSchedule(Long scheduleId) {
@@ -114,13 +143,17 @@ public class ScheduleService {
     }
 
     private void updateSchedulePlace(Schedule schedule, ScheduleUpdateRequest ScheduleRequest) {
-        if (ScheduleRequest.placeIds() == null || ScheduleRequest.placeIds().isEmpty()) return;
+        if (ScheduleRequest.placeIds() == null || ScheduleRequest.placeIds().isEmpty()) {
+            return;
+        }
 
         schedulePlaceService.updateSchedulePlace(schedule, ScheduleRequest);
     }
 
     private void updateScheduleDetail(Schedule schedule, ScheduleUpdateRequest ScheduleRequest) {
-        if (ScheduleRequest.scheduleDetails() == null || ScheduleRequest.scheduleDetails().isEmpty()) return;
+        if (ScheduleRequest.scheduleDetails() == null || ScheduleRequest.scheduleDetails().isEmpty()) {
+            return;
+        }
 
         scheduleDetailService.updateScheduleDetail(schedule, ScheduleRequest);
     }


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- feat/#68 -> dev
- close #68

## Key Changes
<!-- 최대한 자세히 -->
### 일정 목록 조회 API 구현
- 페이징 기법을 사용하여 한 페이지당 5개의 일정 최신순 조회
- Query Patameter로 Page 번호를 받아 해당 페이지에 속하는 일정들이 조회됨

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->
시원씨가 올리신 기록 목록 조회 API와 매우 유사한데,
응답값의 pageNumber 값에 대한 논의가 필요할 듯 합니당

## References
<!-- 참고한 자료-->
X