### PR TITLE
[FEAT] 일정 좋아요 등록 API

### DIFF
--- a/src/main/java/com/triprecord/triprecord/global/config/SecurityConfig.java
+++ b/src/main/java/com/triprecord/triprecord/global/config/SecurityConfig.java
@@ -32,12 +32,10 @@ public class SecurityConfig {
             "/ranks/seasons",
             "/records",
             "/records/{recordId}",
-            "/records/{recordId}/comments",
             "/schedules",
             "/schedules/{scheduleId}",
-            "/schedules/{scheduleId}/comments",
-            "/trip-styles"
-            ,"/locations"
+            "/trip-styles",
+            "/locations"
     };
 
     @Bean

--- a/src/main/java/com/triprecord/triprecord/global/exception/ErrorCode.java
+++ b/src/main/java/com/triprecord/triprecord/global/exception/ErrorCode.java
@@ -30,7 +30,8 @@ public enum ErrorCode {
 
     SCHEDULE_DATE_INVALID(HttpStatus.BAD_REQUEST, "일정 기간이 유효하지 않습니다."),
     SCHEDULE_DETAIL_DATE_INVALID(HttpStatus.BAD_REQUEST, "일정 상세 날짜가 일정 기간을 벗어났습니다."),
-    SCHEDULE_NOT_FOUND(HttpStatus.NOT_FOUND, "일치하는 일정이 없습니다.");
+    SCHEDULE_NOT_FOUND(HttpStatus.NOT_FOUND, "일치하는 일정이 없습니다."),
+    SCHEDULE_ALREADY_LIKED(HttpStatus.CONFLICT, "이미 좋아요를 남긴 일정입니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/triprecord/triprecord/schedule/controller/ScheduleController.java
+++ b/src/main/java/com/triprecord/triprecord/schedule/controller/ScheduleController.java
@@ -27,7 +27,8 @@ public class ScheduleController {
     private final ScheduleService scheduleService;
 
     @PostMapping
-    public ResponseEntity<ResponseMessage> createSchedule(Authentication authentication, @RequestBody @Valid ScheduleCreateRequest request) {
+    public ResponseEntity<ResponseMessage> createSchedule(Authentication authentication,
+                                                          @RequestBody @Valid ScheduleCreateRequest request) {
         Long userId = Long.valueOf(authentication.getName());
         scheduleService.createSchedule(userId, request);
         return ResponseEntity
@@ -36,7 +37,8 @@ public class ScheduleController {
     }
 
     @PatchMapping("/{scheduleId}")
-    public ResponseEntity<ResponseMessage> updateSchedule(Authentication authentication, @PathVariable Long scheduleId, @RequestBody ScheduleUpdateRequest request) {
+    public ResponseEntity<ResponseMessage> updateSchedule(Authentication authentication, @PathVariable Long scheduleId,
+                                                          @RequestBody ScheduleUpdateRequest request) {
         Long userId = Long.valueOf(authentication.getName());
         scheduleService.updateSchedule(userId, scheduleId, request);
         return ResponseEntity
@@ -53,12 +55,23 @@ public class ScheduleController {
     }
 
     @DeleteMapping("/{scheduleId}")
-    public ResponseEntity<ResponseMessage> deleteSchedule(Authentication authentication, @PathVariable Long scheduleId) {
+    public ResponseEntity<ResponseMessage> deleteSchedule(Authentication authentication,
+                                                          @PathVariable Long scheduleId) {
         Long userId = Long.valueOf(authentication.getName());
         scheduleService.deleteSchedule(userId, scheduleId);
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(new ResponseMessage("일정 삭제에 성공했습니다."));
+    }
+
+    @PostMapping("{scheduleId}/likes")
+    public ResponseEntity<ResponseMessage> createScheduleLike(Authentication authentication,
+                                                              @PathVariable Long scheduleId) {
+        Long userId = Long.valueOf(authentication.getName());
+        scheduleService.createScheduleLike(userId, scheduleId);
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(new ResponseMessage("좋아요 등록에 성공했습니다."));
     }
 
 }

--- a/src/main/java/com/triprecord/triprecord/schedule/repository/ScheduleLikeRepository.java
+++ b/src/main/java/com/triprecord/triprecord/schedule/repository/ScheduleLikeRepository.java
@@ -3,6 +3,7 @@ package com.triprecord.triprecord.schedule.repository;
 import com.triprecord.triprecord.schedule.entity.Schedule;
 import com.triprecord.triprecord.schedule.entity.ScheduleLike;
 import com.triprecord.triprecord.user.entity.User;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -10,5 +11,8 @@ import org.springframework.stereotype.Repository;
 public interface ScheduleLikeRepository extends JpaRepository<ScheduleLike, Long> {
 
     Long countByLikedSchedule(Schedule schedule);
+
     Long countScheduleLikeByLikedUser(User user);
+
+    Optional<ScheduleLike> findByLikedUserAndLikedSchedule(User likedUser, Schedule likedSchedule);
 }

--- a/src/main/java/com/triprecord/triprecord/schedule/service/ScheduleLikeService.java
+++ b/src/main/java/com/triprecord/triprecord/schedule/service/ScheduleLikeService.java
@@ -1,7 +1,12 @@
 package com.triprecord.triprecord.schedule.service;
 
+import com.triprecord.triprecord.global.exception.ErrorCode;
+import com.triprecord.triprecord.global.exception.TripRecordException;
 import com.triprecord.triprecord.schedule.entity.Schedule;
+import com.triprecord.triprecord.schedule.entity.ScheduleLike;
 import com.triprecord.triprecord.schedule.repository.ScheduleLikeRepository;
+import com.triprecord.triprecord.user.entity.User;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,5 +20,19 @@ public class ScheduleLikeService {
 
     public Long getScheduleLikeCount(Schedule schedule) {
         return scheduleLikeRepository.countByLikedSchedule(schedule);
+    }
+
+    @Transactional
+    public void createScheduleLike(User user, Schedule schedule) {
+        Optional<ScheduleLike> scheduleLike = scheduleLikeRepository.findByLikedUserAndLikedSchedule(user, schedule);
+        if (scheduleLike.isPresent()) {
+            throw new TripRecordException(ErrorCode.SCHEDULE_ALREADY_LIKED);
+        }
+
+        ScheduleLike newScheduleLike = ScheduleLike.builder()
+                .schedule(schedule)
+                .user(user)
+                .build();
+        scheduleLikeRepository.save(newScheduleLike);
     }
 }

--- a/src/main/java/com/triprecord/triprecord/schedule/service/ScheduleLikeService.java
+++ b/src/main/java/com/triprecord/triprecord/schedule/service/ScheduleLikeService.java
@@ -25,10 +25,9 @@ public class ScheduleLikeService {
     @Transactional
     public void createScheduleLike(User user, Schedule schedule) {
         Optional<ScheduleLike> scheduleLike = scheduleLikeRepository.findByLikedUserAndLikedSchedule(user, schedule);
-        if (scheduleLike.isPresent()) {
+        scheduleLike.ifPresent(it -> {
             throw new TripRecordException(ErrorCode.SCHEDULE_ALREADY_LIKED);
-        }
-
+        });
         ScheduleLike newScheduleLike = ScheduleLike.builder()
                 .schedule(schedule)
                 .user(user)

--- a/src/main/java/com/triprecord/triprecord/schedule/service/ScheduleLikeService.java
+++ b/src/main/java/com/triprecord/triprecord/schedule/service/ScheduleLikeService.java
@@ -6,7 +6,6 @@ import com.triprecord.triprecord.schedule.entity.Schedule;
 import com.triprecord.triprecord.schedule.entity.ScheduleLike;
 import com.triprecord.triprecord.schedule.repository.ScheduleLikeRepository;
 import com.triprecord.triprecord.user.entity.User;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -24,8 +23,7 @@ public class ScheduleLikeService {
 
     @Transactional
     public void createScheduleLike(User user, Schedule schedule) {
-        Optional<ScheduleLike> scheduleLike = scheduleLikeRepository.findByLikedUserAndLikedSchedule(user, schedule);
-        scheduleLike.ifPresent(it -> {
+        scheduleLikeRepository.findByLikedUserAndLikedSchedule(user, schedule).ifPresent(it -> {
             throw new TripRecordException(ErrorCode.SCHEDULE_ALREADY_LIKED);
         });
         ScheduleLike newScheduleLike = ScheduleLike.builder()

--- a/src/main/java/com/triprecord/triprecord/schedule/service/ScheduleService.java
+++ b/src/main/java/com/triprecord/triprecord/schedule/service/ScheduleService.java
@@ -13,14 +13,13 @@ import com.triprecord.triprecord.schedule.entity.SchedulePlace;
 import com.triprecord.triprecord.schedule.repository.ScheduleRepository;
 import com.triprecord.triprecord.user.entity.User;
 import com.triprecord.triprecord.user.service.UserService;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -64,10 +63,13 @@ public class ScheduleService {
         places.stream()
                 .forEach(place -> schedulePlaceService.createSchedulePlace(schedule, place));
 
-        if (request.scheduleDetails().isEmpty()) return;
+        if (request.scheduleDetails().isEmpty()) {
+            return;
+        }
 
         request.scheduleDetails().stream()
-                .forEach(scheduleDetail -> scheduleDetailService.createScheduleDetail(schedule, scheduleDetail.scheduleDetailDate(), scheduleDetail.scheduleDetailContent()));
+                .forEach(scheduleDetail -> scheduleDetailService.createScheduleDetail(schedule,
+                        scheduleDetail.scheduleDetailDate(), scheduleDetail.scheduleDetailContent()));
     }
 
     public ScheduleGetResponse getSchedule(Long scheduleId) {
@@ -113,14 +115,25 @@ public class ScheduleService {
         scheduleRepository.delete(schedule);
     }
 
+    @Transactional
+    public void createScheduleLike(Long userId, Long scheduleId) {
+        User user = userService.getUserOrException(userId);
+        Schedule schedule = getScheduleOrException(scheduleId);
+        scheduleLikeService.createScheduleLike(user, schedule);
+    }
+
     private void updateSchedulePlace(Schedule schedule, ScheduleUpdateRequest ScheduleRequest) {
-        if (ScheduleRequest.placeIds() == null || ScheduleRequest.placeIds().isEmpty()) return;
+        if (ScheduleRequest.placeIds() == null || ScheduleRequest.placeIds().isEmpty()) {
+            return;
+        }
 
         schedulePlaceService.updateSchedulePlace(schedule, ScheduleRequest);
     }
 
     private void updateScheduleDetail(Schedule schedule, ScheduleUpdateRequest ScheduleRequest) {
-        if (ScheduleRequest.scheduleDetails() == null || ScheduleRequest.scheduleDetails().isEmpty()) return;
+        if (ScheduleRequest.scheduleDetails() == null || ScheduleRequest.scheduleDetails().isEmpty()) {
+            return;
+        }
 
         scheduleDetailService.updateScheduleDetail(schedule, ScheduleRequest);
     }


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- feat/#70 -> dev
- close #70

## Key Changes
<!-- 최대한 자세히 -->
### 일정 좋아요 등록 API 구현
- 한 유저가 동일한 게시물에 좋아요를 중복하여 누를 수 없으므로, DB에 저장된 ScheduleLike 데이터 중 Request로 받은 유저와 일정의 정보가 모두 일치한 데이터가 존재한다면 에러를 발생시킴

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->
커밋 실수로 인해 SecurityConfig 파일의 인증 인가 제외 경로의 오류를 수정한 변경사항이 해당 PR 커밋에 존재합니다..!
그리고 우테코 코드 컨벤션을 이용해 컨벤션을 수정하니 코드 이곳저곳에서 수정사항이 발생했어요,, 또륵
양해 부탁드려요 😂😂

## References
<!-- 참고한 자료-->
X
