### PR TITLE
[FEAT] 일정 댓글 삭제 API

### DIFF
--- a/src/main/java/com/triprecord/triprecord/global/exception/ErrorCode.java
+++ b/src/main/java/com/triprecord/triprecord/global/exception/ErrorCode.java
@@ -32,8 +32,9 @@ public enum ErrorCode {
     SCHEDULE_DATE_INVALID(HttpStatus.BAD_REQUEST, "일정 기간이 유효하지 않습니다."),
     SCHEDULE_DETAIL_DATE_INVALID(HttpStatus.BAD_REQUEST, "일정 상세 날짜가 일정 기간을 벗어났습니다."),
     SCHEDULE_NOT_FOUND(HttpStatus.NOT_FOUND, "일치하는 일정이 없습니다."),
-    SCHEDULE_LIKE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 일정에 좋아요를 남기지 않았습니다.");
-    SCHEDULE_ALREADY_LIKED(HttpStatus.CONFLICT, "이미 좋아요를 남긴 일정입니다.");
+    SCHEDULE_LIKE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 일정에 좋아요를 남기지 않았습니다."),
+    SCHEDULE_ALREADY_LIKED(HttpStatus.CONFLICT, "이미 좋아요를 남긴 일정입니다."),
+    SCHEDULE_COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "일치하는 일정 댓글이 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/triprecord/triprecord/schedule/controller/ScheduleController.java
+++ b/src/main/java/com/triprecord/triprecord/schedule/controller/ScheduleController.java
@@ -5,6 +5,7 @@ import com.triprecord.triprecord.schedule.dto.request.ScheduleCreateRequest;
 import com.triprecord.triprecord.schedule.dto.request.ScheduleUpdateRequest;
 import com.triprecord.triprecord.schedule.dto.response.ScheduleGetResponse;
 import com.triprecord.triprecord.schedule.dto.response.SchedulePageGetResponse;
+import com.triprecord.triprecord.schedule.service.ScheduleCommentService;
 import com.triprecord.triprecord.schedule.service.ScheduleService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -28,6 +29,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class ScheduleController {
 
     private final ScheduleService scheduleService;
+    private final ScheduleCommentService scheduleCommentService;
 
     @PostMapping
     public ResponseEntity<ResponseMessage> createSchedule(Authentication authentication,
@@ -93,6 +95,16 @@ public class ScheduleController {
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(new ResponseMessage("좋아요 등록에 성공했습니다."));
+    }
+
+    @DeleteMapping("comments/{scheduleCommentId}")
+    public ResponseEntity<ResponseMessage> deleteScheduleComment(Authentication authentication,
+                                                                 @PathVariable Long scheduleCommentId) {
+        Long userId = Long.valueOf(authentication.getName());
+        scheduleCommentService.deleteScheduleComment(userId, scheduleCommentId);
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(new ResponseMessage("댓글 삭제에 성공했습니다."));
     }
 
 }

--- a/src/main/java/com/triprecord/triprecord/schedule/service/ScheduleCommentService.java
+++ b/src/main/java/com/triprecord/triprecord/schedule/service/ScheduleCommentService.java
@@ -1,7 +1,12 @@
 package com.triprecord.triprecord.schedule.service;
 
+import com.triprecord.triprecord.global.exception.ErrorCode;
+import com.triprecord.triprecord.global.exception.TripRecordException;
 import com.triprecord.triprecord.schedule.entity.Schedule;
+import com.triprecord.triprecord.schedule.entity.ScheduleComment;
 import com.triprecord.triprecord.schedule.repository.ScheduleCommentRepository;
+import com.triprecord.triprecord.user.entity.User;
+import com.triprecord.triprecord.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -12,8 +17,25 @@ import org.springframework.transaction.annotation.Transactional;
 public class ScheduleCommentService {
 
     private final ScheduleCommentRepository scheduleCommentRepository;
+    private final UserService userService;
 
     public Long getScheduleCommentCount(Schedule schedule) {
         return scheduleCommentRepository.countByCommentedSchedule(schedule);
     }
+
+    @Transactional
+    public void deleteScheduleComment(Long userId, Long scheduleCommentId) {
+        User user = userService.getUserOrException(userId);
+        ScheduleComment scheduleComment = getScheduleCommentOrException(scheduleCommentId);
+        if (scheduleComment.getCommentedUser() != user) {
+            throw new TripRecordException(ErrorCode.INVALID_PERMISSION);
+        }
+        scheduleCommentRepository.delete(scheduleComment);
+    }
+
+    public ScheduleComment getScheduleCommentOrException(Long scheduleCommentId) {
+        return scheduleCommentRepository.findById(scheduleCommentId).orElseThrow(() ->
+                new TripRecordException(ErrorCode.SCHEDULE_COMMENT_NOT_FOUND));
+    }
+
 }


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- feat/#81 -> dev
- close #81

## Key Changes
<!-- 최대한 자세히 -->
### 일정 댓글 삭제 API
로그인 한 사용자 정보, 일정 댓글 ID를 받아, 일정 댓글을 삭제하는 API

로그인 한 사용자가 자신이 등록하지 않은 일정 댓글을 삭제하려고 하면 에러를 발생시킵니다.

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->
X

## References
<!-- 참고한 자료-->
X