### PR TITLE
[FIX] 응답 데이터에 유저 좋아요 전송 여부 추가

### DIFF
--- a/src/main/java/com/triprecord/triprecord/record/controller/RecordController.java
+++ b/src/main/java/com/triprecord/triprecord/record/controller/RecordController.java
@@ -8,6 +8,7 @@ import com.triprecord.triprecord.record.controller.response.RecordPageResponse;
 import com.triprecord.triprecord.record.controller.response.RecordResponse;
 import com.triprecord.triprecord.record.service.RecordService;
 import jakarta.validation.Valid;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
@@ -36,13 +37,15 @@ public class RecordController {
     }
 
     @GetMapping()
-    public ResponseEntity<RecordPageResponse> getRecordPage(Pageable pageable) {
-        return ResponseEntity.status(HttpStatus.OK).body(recordService.getRecordPage(pageable));
+    public ResponseEntity<RecordPageResponse> getRecordPage(Authentication authentication, Pageable pageable) {
+        Optional<Long> userId = Optional.ofNullable((authentication == null) ? null : Long.parseLong(authentication.getName()));
+        return ResponseEntity.status(HttpStatus.OK).body(recordService.getRecordPage(userId, pageable));
     }
 
     @GetMapping("/{recordId}")
-    public ResponseEntity<RecordResponse> getRecordData(@PathVariable Long recordId){
-        return ResponseEntity.status(HttpStatus.OK).body(recordService.getRecordResponseData(recordId));
+    public ResponseEntity<RecordResponse> getRecordData(Authentication authentication, @PathVariable Long recordId){
+        Optional<Long> userId = Optional.ofNullable((authentication == null) ? null : Long.parseLong(authentication.getName()));
+        return ResponseEntity.status(HttpStatus.OK).body(recordService.getRecordResponseData(userId, recordId));
     }
 
     @DeleteMapping("/{recordId}")

--- a/src/main/java/com/triprecord/triprecord/record/controller/response/RecordResponse.java
+++ b/src/main/java/com/triprecord/triprecord/record/controller/response/RecordResponse.java
@@ -16,6 +16,7 @@ public record RecordResponse(
         LocalDate tripStartDate,
         LocalDate tripEndDate,
         List<RecordImageData> recordImages,
+        Boolean userLiked,
         Long likeCount,
         Long commentCount
 
@@ -23,6 +24,7 @@ public record RecordResponse(
     public static RecordResponse fromRecordData(Record record,
                                                 List<PlaceBasicData> recordPlaces,
                                                 List<RecordImageData> images,
+                                                Boolean userLiked,
                                                 Long likeCount,
                                                 Long commentCount){
         return new RecordResponse(
@@ -34,6 +36,7 @@ public record RecordResponse(
                 record.getTripStartDate(),
                 record.getTripEndDate(),
                 images,
+                userLiked,
                 likeCount,
                 commentCount
         );

--- a/src/main/java/com/triprecord/triprecord/record/controller/response/RecordResponse.java
+++ b/src/main/java/com/triprecord/triprecord/record/controller/response/RecordResponse.java
@@ -16,7 +16,7 @@ public record RecordResponse(
         LocalDate tripStartDate,
         LocalDate tripEndDate,
         List<RecordImageData> recordImages,
-        Boolean userLiked,
+        Boolean isUserLiked,
         Long likeCount,
         Long commentCount
 

--- a/src/main/java/com/triprecord/triprecord/record/service/RecordLikeService.java
+++ b/src/main/java/com/triprecord/triprecord/record/service/RecordLikeService.java
@@ -19,6 +19,10 @@ public class RecordLikeService {
     private final RecordLikeRepository recordLikeRepository;
 
 
+    public Boolean findUserLikedRecord(Record record, User user) {
+        return recordLikeRepository.findByLikedRecordAndLikedUser(record, user).isPresent();
+    }
+
     public Long getRecordLikeCount(Record record){
         return recordLikeRepository.countByLikedRecord(record);
     }

--- a/src/main/java/com/triprecord/triprecord/record/service/RecordService.java
+++ b/src/main/java/com/triprecord/triprecord/record/service/RecordService.java
@@ -17,10 +17,13 @@ import com.triprecord.triprecord.user.entity.User;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -56,11 +59,11 @@ public class RecordService {
     }
 
     @Transactional(readOnly = true)
-    public RecordPageResponse getRecordPage(Pageable pageable) {
+    public RecordPageResponse getRecordPage(Optional<Long> userId, Pageable pageable) {
         Page<Record> records = recordRepository.findAllOrderById(pageable);
         List<RecordResponse> recordResponses = new ArrayList<>();
         for(Record record : records.getContent()) {
-            recordResponses.add(getRecordResponseData(record.getRecordId()));
+            recordResponses.add(getRecordResponseData(userId, record.getRecordId()));
         }
         return RecordPageResponse.builder()
                 .totalPages(records.getTotalPages())
@@ -70,16 +73,22 @@ public class RecordService {
     }
 
     @Transactional(readOnly = true)
-    public RecordResponse getRecordResponseData(Long recordId) {
+    public RecordResponse getRecordResponseData(Optional<Long> userId, Long recordId) {
         Record record = getRecordOrException(recordId);
 
         List<PlaceBasicData> recordPlaceData = recordPlaceService.getRecordPlaceBasicData(record);
         List<RecordImageData> recordImageData = recordImageService.findRecordImageData(record);
 
+        Boolean userRecordLiked = findUserRecordLiked(userId, record);
         Long likeCount = recordLikeService.getRecordLikeCount(record);
         Long commentCount = recordCommentService.getRecordCommentCount(record);
 
-        return RecordResponse.fromRecordData(record, recordPlaceData, recordImageData, likeCount, commentCount);
+        return RecordResponse.fromRecordData(record, recordPlaceData, recordImageData, userRecordLiked, likeCount, commentCount);
+    }
+
+    private Boolean findUserRecordLiked(Optional<Long> userId, Record record) {
+        if(userId.isPresent()) return recordLikeService.findUserLikedRecord(record, userService.getUserOrException(userId.get()));
+        return false;
     }
 
     @Transactional

--- a/src/main/java/com/triprecord/triprecord/schedule/controller/ScheduleController.java
+++ b/src/main/java/com/triprecord/triprecord/schedule/controller/ScheduleController.java
@@ -7,6 +7,7 @@ import com.triprecord.triprecord.schedule.dto.response.ScheduleGetResponse;
 import com.triprecord.triprecord.schedule.dto.response.SchedulePageGetResponse;
 import com.triprecord.triprecord.schedule.service.ScheduleService;
 import jakarta.validation.Valid;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
@@ -50,16 +51,18 @@ public class ScheduleController {
     }
 
     @GetMapping
-    public ResponseEntity<SchedulePageGetResponse> getSchedules(@PageableDefault(size = 5) Pageable pageable) {
-        SchedulePageGetResponse response = scheduleService.getSchedules(pageable);
+    public ResponseEntity<SchedulePageGetResponse> getSchedules(Authentication authentication, @PageableDefault(size = 5) Pageable pageable) {
+        Optional<Long> userId = Optional.ofNullable((authentication == null) ? null : Long.parseLong(authentication.getName()));
+        SchedulePageGetResponse response = scheduleService.getSchedules(userId, pageable);
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(response);
     }
 
     @GetMapping("/{scheduleId}")
-    public ResponseEntity<ScheduleGetResponse> getSchedule(@PathVariable Long scheduleId) {
-        ScheduleGetResponse response = scheduleService.getSchedule(scheduleId);
+    public ResponseEntity<ScheduleGetResponse> getSchedule(Authentication authentication, @PathVariable Long scheduleId) {
+        Optional<Long> userId = Optional.ofNullable((authentication == null) ? null : Long.parseLong(authentication.getName()));
+        ScheduleGetResponse response = scheduleService.getSchedule(userId, scheduleId);
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(response);

--- a/src/main/java/com/triprecord/triprecord/schedule/dto/response/ScheduleGetResponse.java
+++ b/src/main/java/com/triprecord/triprecord/schedule/dto/response/ScheduleGetResponse.java
@@ -16,6 +16,7 @@ public record ScheduleGetResponse(
         String scheduleStartDate,
         String scheduleEndDate,
         List<ScheduleDetailGetResponse> scheduleDetails,
+        Boolean isUserLiked,
         Long scheduleLikeCount,
         Long scheduleCommentCount
 ) {
@@ -23,6 +24,7 @@ public record ScheduleGetResponse(
                                          Schedule schedule,
                                          List<SchedulePlace> schedulePlaces,
                                          List<ScheduleDetail> scheduleDetails,
+                                         Boolean userLiked,
                                          Long scheduleLikeCount,
                                          Long scheduleCommentCount) {
         return new ScheduleGetResponse(
@@ -37,6 +39,7 @@ public record ScheduleGetResponse(
                 scheduleDetails.stream()
                         .map(ScheduleDetailGetResponse::of)
                         .toList(),
+                userLiked,
                 scheduleLikeCount,
                 scheduleCommentCount
         );

--- a/src/main/java/com/triprecord/triprecord/schedule/service/ScheduleLikeService.java
+++ b/src/main/java/com/triprecord/triprecord/schedule/service/ScheduleLikeService.java
@@ -2,6 +2,7 @@ package com.triprecord.triprecord.schedule.service;
 
 import com.triprecord.triprecord.global.exception.ErrorCode;
 import com.triprecord.triprecord.global.exception.TripRecordException;
+import com.triprecord.triprecord.record.entity.Record;
 import com.triprecord.triprecord.schedule.entity.Schedule;
 import com.triprecord.triprecord.schedule.entity.ScheduleLike;
 import com.triprecord.triprecord.schedule.repository.ScheduleLikeRepository;
@@ -16,6 +17,10 @@ import org.springframework.transaction.annotation.Transactional;
 public class ScheduleLikeService {
 
     private final ScheduleLikeRepository scheduleLikeRepository;
+
+    public Boolean findUserLikedSchedule(Schedule schedule, User user) {
+        return scheduleLikeRepository.findByLikedUserAndLikedSchedule(user, schedule).isPresent();
+    }
 
     public Long getScheduleLikeCount(Schedule schedule) {
         return scheduleLikeRepository.countByLikedSchedule(schedule);

--- a/src/main/java/com/triprecord/triprecord/schedule/service/ScheduleService.java
+++ b/src/main/java/com/triprecord/triprecord/schedule/service/ScheduleService.java
@@ -4,6 +4,7 @@ import com.triprecord.triprecord.global.exception.ErrorCode;
 import com.triprecord.triprecord.global.exception.TripRecordException;
 import com.triprecord.triprecord.location.PlaceService;
 import com.triprecord.triprecord.location.entity.Place;
+import com.triprecord.triprecord.record.entity.Record;
 import com.triprecord.triprecord.schedule.dto.request.ScheduleCreateRequest;
 import com.triprecord.triprecord.schedule.dto.request.ScheduleUpdateRequest;
 import com.triprecord.triprecord.schedule.dto.response.ScheduleGetResponse;
@@ -18,6 +19,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -75,18 +77,20 @@ public class ScheduleService {
                         scheduleDetail.scheduleDetailDate(), scheduleDetail.scheduleDetailContent()));
     }
 
-    public SchedulePageGetResponse getSchedules(Pageable pageable) {
+    public SchedulePageGetResponse getSchedules(Optional<Long> userId, Pageable pageable) {
         Page<Schedule> schedules = scheduleRepository.findAllOrderById(pageable);
         List<ScheduleGetResponse> scheduleGetResponses = new ArrayList<>();
 
         for (Schedule schedule : schedules.getContent()) {
             long scheduleLikeCount = scheduleLikeService.getScheduleLikeCount(schedule);
             long scheduleCommentCount = scheduleCommentService.getScheduleCommentCount(schedule);
+            Boolean userScheduleLiked = findUserScheduleLiked(userId, schedule);
             scheduleGetResponses.add(ScheduleGetResponse.of(
                     schedule.getCreatedUser(),
                     schedule,
                     schedule.getSchedulePlaces(),
                     schedule.getScheduleDetails(),
+                    userScheduleLiked,
                     scheduleLikeCount,
                     scheduleCommentCount
             ));
@@ -99,7 +103,7 @@ public class ScheduleService {
                 .build();
     }
 
-    public ScheduleGetResponse getSchedule(Long scheduleId) {
+    public ScheduleGetResponse getSchedule(Optional<Long> userId, Long scheduleId) {
         Schedule schedule = getScheduleOrException(scheduleId);
         User createdUser = schedule.getCreatedUser();
         List<SchedulePlace> schedulePlaces = schedule.getSchedulePlaces();
@@ -107,6 +111,7 @@ public class ScheduleService {
         List<ScheduleDetail> scheduleDetails = schedule.getScheduleDetails();
         Collections.sort(scheduleDetails, Comparator.comparing(ScheduleDetail::getScheduleDetailDate));
 
+        Boolean userScheduleLiked = findUserScheduleLiked(userId, schedule);
         Long scheduleLikeCount = scheduleLikeService.getScheduleLikeCount(schedule);
         Long scheduleCommentCount = scheduleCommentService.getScheduleCommentCount(schedule);
 
@@ -115,9 +120,15 @@ public class ScheduleService {
                 schedule,
                 schedulePlaces,
                 scheduleDetails,
+                userScheduleLiked,
                 scheduleLikeCount,
                 scheduleCommentCount
         );
+    }
+
+    private Boolean findUserScheduleLiked(Optional<Long> userId, Schedule schedule) {
+        if(userId.isPresent()) return scheduleLikeService.findUserLikedSchedule(schedule, userService.getUserOrException(userId.get()));
+        return false;
     }
 
     @Transactional


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- feat/#74 -> dev
- close #74

## Key Changes
<!-- 최대한 자세히 -->
기록/스케쥴 등의 데이터 응답 데이터에 
현재 로그인한 유저가 좋아요를 전송했는지 알 수 있도록 Boolean 타입 필드를 추가했습니다.
- 현재 로그인된 유저가 없는 경우 false
- 로그인된 유저가 해당 기록/스케쥴에 좋아요를 남기지 않았다면 false
- 로그인된 유저가 해당 기록/스케쥴에 좋아요를 남겼다면 ture

기록/스케쥴 조회 api는 토큰값이 필수가 아니기 때문에 null 처리를 위한 로직이 포함되어 있습니다.

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->
제가 채은씨 담당의 스케쥴부분도 같이 수정하기로 했는데, 일단 의견을 먼저 받고 수정 후에 함께 진행하겠습니다!
(현재 PR에 포함된 커밋은 Record 부분만 반영되어 있습니다.)

**의견을 받고 싶은 부분**
여러 레코드를 return 해줘야 하는 api(/records)의 경우,
user 인증을 한번만 하고 싶은데, 현재 구현은 해당 레코드의 좋아요 여부를 찾을때마다 유저 여부를 찾게 됩니다.
이 부분은 어떻게 개선하면 좋을지 함께 고민해보면 좋을 것 같아요! 의견주세요~ 🙇‍♀️

## References
<!-- 참고한 자료-->
