### PR TITLE
[FEAT] 유저의 일정만 불러오는 API

### DIFF
--- a/src/main/java/com/triprecord/triprecord/global/exception/ErrorCode.java
+++ b/src/main/java/com/triprecord/triprecord/global/exception/ErrorCode.java
@@ -32,7 +32,7 @@ public enum ErrorCode {
     SCHEDULE_DATE_INVALID(HttpStatus.BAD_REQUEST, "일정 기간이 유효하지 않습니다."),
     SCHEDULE_DETAIL_DATE_INVALID(HttpStatus.BAD_REQUEST, "일정 상세 날짜가 일정 기간을 벗어났습니다."),
     SCHEDULE_NOT_FOUND(HttpStatus.NOT_FOUND, "일치하는 일정이 없습니다."),
-    SCHEDULE_LIKE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 일정에 좋아요를 남기지 않았습니다.");
+    SCHEDULE_LIKE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 일정에 좋아요를 남기지 않았습니다."),
     SCHEDULE_ALREADY_LIKED(HttpStatus.CONFLICT, "이미 좋아요를 남긴 일정입니다.");
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/triprecord/triprecord/schedule/dto/response/ScheduleInfo.java
+++ b/src/main/java/com/triprecord/triprecord/schedule/dto/response/ScheduleInfo.java
@@ -1,0 +1,37 @@
+package com.triprecord.triprecord.schedule.dto.response;
+
+import com.triprecord.triprecord.schedule.entity.Schedule;
+import com.triprecord.triprecord.schedule.entity.ScheduleDetail;
+import com.triprecord.triprecord.schedule.entity.SchedulePlace;
+import java.util.List;
+
+public record ScheduleInfo(
+        Long scheduleId,
+        String scheduleTitle,
+        List<SchedulePlaceGetResponse> schedulePlaces,
+        String scheduleStartDate,
+        String scheduleEndDate,
+        List<ScheduleDetailGetResponse> scheduleDetails,
+        Long scheduleLikeCount,
+        Long scheduleCommentCount) {
+    public static ScheduleInfo of(Schedule schedule,
+                                         List<SchedulePlace> schedulePlaces,
+                                         List<ScheduleDetail> scheduleDetails,
+                                         Long scheduleLikeCount,
+                                         Long scheduleCommentCount){
+        return new ScheduleInfo(
+                schedule.getScheduleId(),
+                schedule.getScheduleTitle(),
+                schedulePlaces.stream()
+                        .map(SchedulePlaceGetResponse::of)
+                        .toList(),
+                schedule.getScheduleStartDate().toString(),
+                schedule.getScheduleEndDate().toString(),
+                scheduleDetails.stream()
+                        .map(ScheduleDetailGetResponse::of)
+                        .toList(),
+                scheduleLikeCount,
+                scheduleCommentCount
+        );
+    }
+}

--- a/src/main/java/com/triprecord/triprecord/schedule/repository/ScheduleRepository.java
+++ b/src/main/java/com/triprecord/triprecord/schedule/repository/ScheduleRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -15,4 +16,7 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
 
     @Query("SELECT s FROM Schedule s ORDER BY s.scheduleId DESC")
     Page<Schedule> findAllOrderById(Pageable pageable);
+
+    @Query("SELECT s FROM Schedule s WHERE s.createdUser.userId = :uid ORDER BY s.scheduleId DESC ")
+    Page<Schedule> findAllByCreatedUser(@Param("uid") Long userId, Pageable pageable);
 }

--- a/src/main/java/com/triprecord/triprecord/schedule/repository/ScheduleRepository.java
+++ b/src/main/java/com/triprecord/triprecord/schedule/repository/ScheduleRepository.java
@@ -17,6 +17,5 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
     @Query("SELECT s FROM Schedule s ORDER BY s.scheduleId DESC")
     Page<Schedule> findAllOrderById(Pageable pageable);
 
-    @Query("SELECT s FROM Schedule s WHERE s.createdUser.userId = :uid ORDER BY s.scheduleId DESC ")
-    Page<Schedule> findAllByCreatedUser(@Param("uid") Long userId, Pageable pageable);
+    Page<Schedule> findAllByCreatedUser(User user, Pageable pageable);
 }

--- a/src/main/java/com/triprecord/triprecord/schedule/repository/ScheduleRepository.java
+++ b/src/main/java/com/triprecord/triprecord/schedule/repository/ScheduleRepository.java
@@ -17,5 +17,6 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
     @Query("SELECT s FROM Schedule s ORDER BY s.scheduleId DESC")
     Page<Schedule> findAllOrderById(Pageable pageable);
 
-    Page<Schedule> findAllByCreatedUser(User user, Pageable pageable);
+    @Query("SELECT s FROM Schedule s WHERE s.createdUser.userId = :uid ORDER BY s.scheduleId DESC ")
+    Page<Schedule> findAllByCreatedUser(@Param("uid") Long userId, Pageable pageable);
 }

--- a/src/main/java/com/triprecord/triprecord/user/controller/UserController.java
+++ b/src/main/java/com/triprecord/triprecord/user/controller/UserController.java
@@ -1,12 +1,15 @@
 package com.triprecord.triprecord.user.controller;
 
 import com.triprecord.triprecord.global.util.ResponseMessage;
+import com.triprecord.triprecord.schedule.dto.response.SchedulePageGetResponse;
 import com.triprecord.triprecord.user.dto.request.UserCreateRequest;
 import com.triprecord.triprecord.user.dto.response.UserInfoGetResponse;
 import com.triprecord.triprecord.user.dto.request.UserLoginRequest;
 import com.triprecord.triprecord.user.service.UserService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
@@ -46,5 +49,12 @@ public class UserController {
     @GetMapping("/informations")
     public ResponseEntity<UserInfoGetResponse> userInfo(Authentication authentication){
         return ResponseEntity.status(HttpStatus.OK).body(userService.getUserInfo(Long.valueOf(authentication.getName())));
+    }
+
+    @GetMapping("/schedules")
+    public ResponseEntity<SchedulePageGetResponse> userSchedules(Authentication authentication, @PageableDefault(size = 5) Pageable pageable){
+        SchedulePageGetResponse response = userService.getUserSchedules(Long.valueOf(authentication.getName()), pageable);
+        return ResponseEntity.status(HttpStatus.OK).body(response);
+
     }
 }

--- a/src/main/java/com/triprecord/triprecord/user/controller/UserController.java
+++ b/src/main/java/com/triprecord/triprecord/user/controller/UserController.java
@@ -5,6 +5,7 @@ import com.triprecord.triprecord.schedule.dto.response.SchedulePageGetResponse;
 import com.triprecord.triprecord.user.dto.request.UserCreateRequest;
 import com.triprecord.triprecord.user.dto.response.UserInfoGetResponse;
 import com.triprecord.triprecord.user.dto.request.UserLoginRequest;
+import com.triprecord.triprecord.user.dto.response.UserSchedulePageResponse;
 import com.triprecord.triprecord.user.service.UserService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -52,8 +53,8 @@ public class UserController {
     }
 
     @GetMapping("/schedules")
-    public ResponseEntity<SchedulePageGetResponse> userSchedules(Authentication authentication, @PageableDefault(size = 5) Pageable pageable){
-        SchedulePageGetResponse response = userService.getUserSchedules(Long.valueOf(authentication.getName()), pageable);
+    public ResponseEntity<UserSchedulePageResponse> userSchedules(Authentication authentication, @PageableDefault(size = 5) Pageable pageable){
+        UserSchedulePageResponse response = userService.getUserSchedules(Long.valueOf(authentication.getName()), pageable);
         return ResponseEntity.status(HttpStatus.OK).body(response);
 
     }

--- a/src/main/java/com/triprecord/triprecord/user/dto/response/UserSchedulePageResponse.java
+++ b/src/main/java/com/triprecord/triprecord/user/dto/response/UserSchedulePageResponse.java
@@ -1,0 +1,16 @@
+package com.triprecord.triprecord.user.dto.response;
+
+import com.triprecord.triprecord.schedule.dto.response.ScheduleInfo;
+
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record UserSchedulePageResponse(
+        int totalPages,
+        int pageNumber,
+        List<ScheduleInfo> scheduleInfoList
+
+
+) {
+}

--- a/src/main/java/com/triprecord/triprecord/user/service/UserService.java
+++ b/src/main/java/com/triprecord/triprecord/user/service/UserService.java
@@ -9,6 +9,7 @@ import com.triprecord.triprecord.record.repository.RecordLikeRepository;
 import com.triprecord.triprecord.record.repository.RecordPlaceRepository;
 import com.triprecord.triprecord.record.repository.RecordRepository;
 import com.triprecord.triprecord.schedule.dto.response.ScheduleGetResponse;
+import com.triprecord.triprecord.schedule.dto.response.ScheduleInfo;
 import com.triprecord.triprecord.schedule.dto.response.SchedulePageGetResponse;
 import com.triprecord.triprecord.schedule.entity.Schedule;
 import com.triprecord.triprecord.schedule.repository.ScheduleLikeRepository;
@@ -18,6 +19,7 @@ import com.triprecord.triprecord.schedule.service.ScheduleLikeService;
 import com.triprecord.triprecord.user.dto.request.UserCreateRequest;
 import com.triprecord.triprecord.user.dto.request.UserLoginRequest;
 import com.triprecord.triprecord.user.dto.response.UserInfoGetResponse;
+import com.triprecord.triprecord.user.dto.response.UserSchedulePageResponse;
 import com.triprecord.triprecord.user.entity.User;
 import com.triprecord.triprecord.user.repository.UserRepository;
 import java.util.ArrayList;
@@ -89,15 +91,14 @@ public class UserService {
         return UserInfoGetResponse.of(user, recordTotal, scheduleTotal, placeTotal, likeTotal);
     }
 
-    public SchedulePageGetResponse getUserSchedules(Long userId, Pageable pageable){
+    public UserSchedulePageResponse getUserSchedules(Long userId, Pageable pageable){
         Page<Schedule> schedules = scheduleRepository.findAllByCreatedUser(userId, pageable);
-        List<ScheduleGetResponse> userScheduleGetResponse = new ArrayList<>();
+        List<ScheduleInfo> userScheduleGetResponse = new ArrayList<>();
 
         for(Schedule schedule : schedules.getContent()){
             long scheduleLikeCount = scheduleLikeService.getScheduleLikeCount(schedule);
             long scheduleCommentCount = scheduleCommentService.getScheduleCommentCount(schedule);
-            userScheduleGetResponse.add(ScheduleGetResponse.of(
-                    schedule.getCreatedUser(),
+            userScheduleGetResponse.add(ScheduleInfo.of(
                     schedule,
                     schedule.getSchedulePlaces(),
                     schedule.getScheduleDetails(),
@@ -106,10 +107,10 @@ public class UserService {
             ));
         }
 
-        return SchedulePageGetResponse.builder()
+        return UserSchedulePageResponse.builder()
                 .totalPages(schedules.getTotalPages())
                 .pageNumber(schedules.getNumber())
-                .schedules(userScheduleGetResponse)
+                .scheduleInfoList(userScheduleGetResponse)
                 .build();
     }
 

--- a/src/main/java/com/triprecord/triprecord/user/service/UserService.java
+++ b/src/main/java/com/triprecord/triprecord/user/service/UserService.java
@@ -90,8 +90,7 @@ public class UserService {
     }
 
     public SchedulePageGetResponse getUserSchedules(Long userId, Pageable pageable){
-        User user = getUserOrException(userId);
-        Page<Schedule> schedules = scheduleRepository.findAllByCreatedUser(user, pageable);
+        Page<Schedule> schedules = scheduleRepository.findAllByCreatedUser(userId, pageable);
         List<ScheduleGetResponse> userScheduleGetResponse = new ArrayList<>();
 
         for(Schedule schedule : schedules.getContent()){

--- a/src/main/java/com/triprecord/triprecord/user/service/UserService.java
+++ b/src/main/java/com/triprecord/triprecord/user/service/UserService.java
@@ -90,7 +90,8 @@ public class UserService {
     }
 
     public SchedulePageGetResponse getUserSchedules(Long userId, Pageable pageable){
-        Page<Schedule> schedules = scheduleRepository.findAllByCreatedUser(userId, pageable);
+        User user = getUserOrException(userId);
+        Page<Schedule> schedules = scheduleRepository.findAllByCreatedUser(user, pageable);
         List<ScheduleGetResponse> userScheduleGetResponse = new ArrayList<>();
 
         for(Schedule schedule : schedules.getContent()){


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- feat/#84 -> dev
- close #84

## Key Changes
<!-- 최대한 자세히 -->
로그인한 유저의 마이페이지에 나타내는 일정 정보들을 불러오는 API 입니다.
해당 페이지에는 유저가 올린 일정 게시물만 불러와지며 pageable을 이용해서 구현했습니다.

![image](https://github.com/Trip-Record/Server/assets/126096318/8af64d78-8bda-4729-828a-9cc7e62eb6d3)
![image](https://github.com/Trip-Record/Server/assets/126096318/5e98e004-5c03-4673-ac1d-42148e1898a8)

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->
그 전 채은씨가 구현한 일정 목록을 불러오는 API를 이용해서 구현했습니다.
다른 점은 전체 일정을 불러오는 것이 아닌 로그인한 유저가 작성한 일정 게시물만 불러온다는 점입니다.

이전에 전체 일정을 불러오는 API에서 SchedulePageGetResponse DTO를 사용했기에 우선 저도 동일하게 사용하였는데,
그렇게 하니까 SchedulePageGetResponse 안에 있던 ScheduleGetResponse 리스트의 userProfile 정보까지 불러와져 불필요한 정보를 불러오는 것이 아닌가 하는 생각이 듭니다..! 따로 userProfile 가 없는 DTO를 만들어야 할 지, 아니면 그대로 그냥 적용 시킬지 고민이 되는데 의견 있으시면 말씁해주세요!!

## References
<!-- 참고한 자료-->
