### PR TITLE
[FEAT] 유저의 기록만 불러오는 API

### DIFF
--- a/src/main/java/com/triprecord/triprecord/global/exception/ErrorCode.java
+++ b/src/main/java/com/triprecord/triprecord/global/exception/ErrorCode.java
@@ -32,7 +32,7 @@ public enum ErrorCode {
     SCHEDULE_DATE_INVALID(HttpStatus.BAD_REQUEST, "일정 기간이 유효하지 않습니다."),
     SCHEDULE_DETAIL_DATE_INVALID(HttpStatus.BAD_REQUEST, "일정 상세 날짜가 일정 기간을 벗어났습니다."),
     SCHEDULE_NOT_FOUND(HttpStatus.NOT_FOUND, "일치하는 일정이 없습니다."),
-    SCHEDULE_LIKE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 일정에 좋아요를 남기지 않았습니다.");
+    SCHEDULE_LIKE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 일정에 좋아요를 남기지 않았습니다."),
     SCHEDULE_ALREADY_LIKED(HttpStatus.CONFLICT, "이미 좋아요를 남긴 일정입니다.");
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/triprecord/triprecord/record/dto/RecordInfo.java
+++ b/src/main/java/com/triprecord/triprecord/record/dto/RecordInfo.java
@@ -1,0 +1,37 @@
+package com.triprecord.triprecord.record.dto;
+
+import com.triprecord.triprecord.location.dto.PlaceBasicData;
+import com.triprecord.triprecord.record.entity.Record;
+import java.time.LocalDate;
+import java.util.List;
+
+public record RecordInfo(
+        List<PlaceBasicData> recordPlaces,
+        Long recordId,
+        String recordTitle,
+        String recordContent,
+        LocalDate tripStartDate,
+        LocalDate tripEndDate,
+        List<RecordImageData> recordImages,
+        Long likeCount,
+        Long commentCount
+) {
+
+    public static RecordInfo of(Record record,
+                                List<PlaceBasicData> recordPlaces,
+                                List<RecordImageData> images,
+                                Long likeCount,
+                                Long commentCount){
+        return new RecordInfo(
+                recordPlaces,
+                record.getRecordId(),
+                record.getRecordTitle(),
+                record.getRecordContent(),
+                record.getTripStartDate(),
+                record.getTripEndDate(),
+                images,
+                likeCount,
+                commentCount
+        );
+    }
+}

--- a/src/main/java/com/triprecord/triprecord/record/repository/RecordRepository.java
+++ b/src/main/java/com/triprecord/triprecord/record/repository/RecordRepository.java
@@ -21,7 +21,6 @@ public interface RecordRepository extends JpaRepository<Record, Long> {
     @Query("SELECT r FROM Record r ORDER BY r.recordId DESC ")
     Page<Record> findAllOrderById(Pageable pageable);
 
-    @Query("SELECT r FROM Record r WHERE r.createdUser.userId = :uid ORDER BY r.recordId DESC ")
-    Page<Record> findAllByCreatedUser(@Param("uid") Long userId, Pageable pageable);
+    Page<Record> findAllByCreatedUser(User user, Pageable pageable);
 
 }

--- a/src/main/java/com/triprecord/triprecord/record/repository/RecordRepository.java
+++ b/src/main/java/com/triprecord/triprecord/record/repository/RecordRepository.java
@@ -8,7 +8,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository

--- a/src/main/java/com/triprecord/triprecord/record/repository/RecordRepository.java
+++ b/src/main/java/com/triprecord/triprecord/record/repository/RecordRepository.java
@@ -20,4 +20,8 @@ public interface RecordRepository extends JpaRepository<Record, Long> {
 
     @Query("SELECT r FROM Record r ORDER BY r.recordId DESC ")
     Page<Record> findAllOrderById(Pageable pageable);
+
+    @Query("SELECT r FROM Record r WHERE r.createdUser.userId = :uid ORDER BY r.recordId DESC ")
+    Page<Record> findAllByCreatedUser(@Param("uid") Long userId, Pageable pageable);
+
 }

--- a/src/main/java/com/triprecord/triprecord/record/repository/RecordRepository.java
+++ b/src/main/java/com/triprecord/triprecord/record/repository/RecordRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -20,6 +21,7 @@ public interface RecordRepository extends JpaRepository<Record, Long> {
     @Query("SELECT r FROM Record r ORDER BY r.recordId DESC ")
     Page<Record> findAllOrderById(Pageable pageable);
 
-    Page<Record> findAllByCreatedUser(User user, Pageable pageable);
+    @Query("SELECT r FROM Record r WHERE r.createdUser.userId = :uid ORDER BY r.recordId DESC ")
+    Page<Record> findAllByCreatedUser(@Param("uid") Long userId, Pageable pageable);
 
 }

--- a/src/main/java/com/triprecord/triprecord/user/controller/UserController.java
+++ b/src/main/java/com/triprecord/triprecord/user/controller/UserController.java
@@ -5,6 +5,7 @@ import com.triprecord.triprecord.record.controller.response.RecordPageResponse;
 import com.triprecord.triprecord.user.dto.request.UserCreateRequest;
 import com.triprecord.triprecord.user.dto.response.UserInfoGetResponse;
 import com.triprecord.triprecord.user.dto.request.UserLoginRequest;
+import com.triprecord.triprecord.user.dto.response.UserRecordPageResponse;
 import com.triprecord.triprecord.user.service.UserService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -49,8 +50,8 @@ public class UserController {
         return ResponseEntity.status(HttpStatus.OK).body(userService.getUserInfo(Long.valueOf(authentication.getName())));
     }
     @GetMapping("/records")
-    public ResponseEntity<RecordPageResponse> getUserRecords(Authentication authentication, @PageableDefault(size = 5) Pageable pageable){
-        RecordPageResponse response = userService.getUserRecords(Long.valueOf(authentication.getName()), pageable);
+    public ResponseEntity<UserRecordPageResponse> getUserRecords(Authentication authentication, @PageableDefault(size = 5) Pageable pageable){
+        UserRecordPageResponse response = userService.getUserRecords(Long.valueOf(authentication.getName()), pageable);
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 }

--- a/src/main/java/com/triprecord/triprecord/user/controller/UserController.java
+++ b/src/main/java/com/triprecord/triprecord/user/controller/UserController.java
@@ -1,12 +1,15 @@
 package com.triprecord.triprecord.user.controller;
 
 import com.triprecord.triprecord.global.util.ResponseMessage;
+import com.triprecord.triprecord.record.controller.response.RecordPageResponse;
 import com.triprecord.triprecord.user.dto.request.UserCreateRequest;
 import com.triprecord.triprecord.user.dto.response.UserInfoGetResponse;
 import com.triprecord.triprecord.user.dto.request.UserLoginRequest;
 import com.triprecord.triprecord.user.service.UserService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
@@ -15,8 +18,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.net.URI;
 
 import java.util.Map;
 
@@ -46,5 +47,10 @@ public class UserController {
     @GetMapping("/informations")
     public ResponseEntity<UserInfoGetResponse> userInfo(Authentication authentication){
         return ResponseEntity.status(HttpStatus.OK).body(userService.getUserInfo(Long.valueOf(authentication.getName())));
+    }
+    @GetMapping("/records")
+    public ResponseEntity<RecordPageResponse> getUserRecords(Authentication authentication, @PageableDefault(size = 5) Pageable pageable){
+        RecordPageResponse response = userService.getUserRecords(Long.valueOf(authentication.getName()), pageable);
+        return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 }

--- a/src/main/java/com/triprecord/triprecord/user/dto/response/UserRecordPageResponse.java
+++ b/src/main/java/com/triprecord/triprecord/user/dto/response/UserRecordPageResponse.java
@@ -1,0 +1,14 @@
+package com.triprecord.triprecord.user.dto.response;
+
+import com.triprecord.triprecord.record.dto.RecordInfo;
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record UserRecordPageResponse(
+        int totalPages,
+        int pageNumber,
+        List<RecordInfo> recordInfoList
+) {
+}

--- a/src/main/java/com/triprecord/triprecord/user/service/UserService.java
+++ b/src/main/java/com/triprecord/triprecord/user/service/UserService.java
@@ -5,9 +5,18 @@ import com.triprecord.triprecord.global.config.jwt.JwtProvider;
 import com.triprecord.triprecord.global.config.jwt.UserAuthentication;
 import com.triprecord.triprecord.global.exception.ErrorCode;
 import com.triprecord.triprecord.global.exception.TripRecordException;
+import com.triprecord.triprecord.location.dto.PlaceBasicData;
+import com.triprecord.triprecord.record.controller.response.RecordPageResponse;
+import com.triprecord.triprecord.record.controller.response.RecordResponse;
+import com.triprecord.triprecord.record.dto.RecordImageData;
+import com.triprecord.triprecord.record.entity.Record;
 import com.triprecord.triprecord.record.repository.RecordLikeRepository;
 import com.triprecord.triprecord.record.repository.RecordPlaceRepository;
 import com.triprecord.triprecord.record.repository.RecordRepository;
+import com.triprecord.triprecord.record.service.RecordCommentService;
+import com.triprecord.triprecord.record.service.RecordImageService;
+import com.triprecord.triprecord.record.service.RecordLikeService;
+import com.triprecord.triprecord.record.service.RecordPlaceService;
 import com.triprecord.triprecord.schedule.repository.ScheduleLikeRepository;
 import com.triprecord.triprecord.schedule.repository.ScheduleRepository;
 import com.triprecord.triprecord.user.dto.request.UserCreateRequest;
@@ -15,12 +24,16 @@ import com.triprecord.triprecord.user.dto.request.UserLoginRequest;
 import com.triprecord.triprecord.user.dto.response.UserInfoGetResponse;
 import com.triprecord.triprecord.user.entity.User;
 import com.triprecord.triprecord.user.repository.UserRepository;
+import java.util.ArrayList;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -36,6 +49,10 @@ public class UserService {
     private final ScheduleLikeRepository scheduleLikeRepository;
     private final BasicProfileRepository basicProfileRepository;
     private final PasswordEncoder passwordEncoder;
+    private final RecordLikeService recordLikeService;
+    private final RecordCommentService recordCommentService;
+    private final RecordPlaceService recordPlaceService;
+    private final RecordImageService recordImageService;
 
     @Transactional
     public String signup(UserCreateRequest userCreateRequest) {
@@ -76,6 +93,27 @@ public class UserService {
         Long likeTotal = getLikesCount(user);
 
         return UserInfoGetResponse.of(user, recordTotal, scheduleTotal, placeTotal, likeTotal);
+    }
+
+    public RecordPageResponse getUserRecords(Long userId, Pageable pageable){
+        Page<Record> records = recordRepository.findAllByCreatedUser(userId, pageable);
+        List<RecordResponse> userRecordGetResponse = new ArrayList<>();
+
+        for(Record record : records.getContent()){
+            List<PlaceBasicData> userRecordPlaceData = recordPlaceService.getRecordPlaceBasicData(record);
+            List<RecordImageData> userRecordImageData = recordImageService.findRecordImageData(record);
+
+            Long recordLikeCount = recordLikeService.getRecordLikeCount(record);
+            Long recordCommentCount = recordCommentService.getRecordCommentCount(record);
+
+            userRecordGetResponse.add(RecordResponse.fromRecordData(record, userRecordPlaceData, userRecordImageData, recordLikeCount, recordCommentCount));
+        }
+
+        return RecordPageResponse.builder()
+                .totalPages(records.getTotalPages())
+                .pageNumber(records.getNumber() + 1)
+                .recordList(userRecordGetResponse)
+                .build();
     }
 
     public Long getLikesCount(User user){

--- a/src/main/java/com/triprecord/triprecord/user/service/UserService.java
+++ b/src/main/java/com/triprecord/triprecord/user/service/UserService.java
@@ -111,7 +111,7 @@ public class UserService {
 
         return RecordPageResponse.builder()
                 .totalPages(records.getTotalPages())
-                .pageNumber(records.getNumber() + 1)
+                .pageNumber(records.getNumber())
                 .recordList(userRecordGetResponse)
                 .build();
     }

--- a/src/main/java/com/triprecord/triprecord/user/service/UserService.java
+++ b/src/main/java/com/triprecord/triprecord/user/service/UserService.java
@@ -9,6 +9,7 @@ import com.triprecord.triprecord.location.dto.PlaceBasicData;
 import com.triprecord.triprecord.record.controller.response.RecordPageResponse;
 import com.triprecord.triprecord.record.controller.response.RecordResponse;
 import com.triprecord.triprecord.record.dto.RecordImageData;
+import com.triprecord.triprecord.record.dto.RecordInfo;
 import com.triprecord.triprecord.record.entity.Record;
 import com.triprecord.triprecord.record.repository.RecordLikeRepository;
 import com.triprecord.triprecord.record.repository.RecordPlaceRepository;
@@ -22,6 +23,7 @@ import com.triprecord.triprecord.schedule.repository.ScheduleRepository;
 import com.triprecord.triprecord.user.dto.request.UserCreateRequest;
 import com.triprecord.triprecord.user.dto.request.UserLoginRequest;
 import com.triprecord.triprecord.user.dto.response.UserInfoGetResponse;
+import com.triprecord.triprecord.user.dto.response.UserRecordPageResponse;
 import com.triprecord.triprecord.user.entity.User;
 import com.triprecord.triprecord.user.repository.UserRepository;
 import java.util.ArrayList;
@@ -95,9 +97,9 @@ public class UserService {
         return UserInfoGetResponse.of(user, recordTotal, scheduleTotal, placeTotal, likeTotal);
     }
 
-    public RecordPageResponse getUserRecords(Long userId, Pageable pageable){
+    public UserRecordPageResponse getUserRecords(Long userId, Pageable pageable){
         Page<Record> records = recordRepository.findAllByCreatedUser(userId, pageable);
-        List<RecordResponse> userRecordGetResponse = new ArrayList<>();
+        List<RecordInfo> userRecordGetResponse = new ArrayList<>();
 
         for(Record record : records.getContent()){
             List<PlaceBasicData> userRecordPlaceData = recordPlaceService.getRecordPlaceBasicData(record);
@@ -106,13 +108,14 @@ public class UserService {
             Long recordLikeCount = recordLikeService.getRecordLikeCount(record);
             Long recordCommentCount = recordCommentService.getRecordCommentCount(record);
 
-            userRecordGetResponse.add(RecordResponse.fromRecordData(record, userRecordPlaceData, userRecordImageData, recordLikeCount, recordCommentCount));
+            userRecordGetResponse.add(
+                    RecordInfo.of(record, userRecordPlaceData, userRecordImageData, recordLikeCount, recordCommentCount));
         }
 
-        return RecordPageResponse.builder()
+        return UserRecordPageResponse.builder()
                 .totalPages(records.getTotalPages())
                 .pageNumber(records.getNumber())
-                .recordList(userRecordGetResponse)
+                .recordInfoList(userRecordGetResponse)
                 .build();
     }
 

--- a/src/main/java/com/triprecord/triprecord/user/service/UserService.java
+++ b/src/main/java/com/triprecord/triprecord/user/service/UserService.java
@@ -96,7 +96,8 @@ public class UserService {
     }
 
     public RecordPageResponse getUserRecords(Long userId, Pageable pageable){
-        Page<Record> records = recordRepository.findAllByCreatedUser(userId, pageable);
+        User user = getUserOrException(userId);
+        Page<Record> records = recordRepository.findAllByCreatedUser(user, pageable);
         List<RecordResponse> userRecordGetResponse = new ArrayList<>();
 
         for(Record record : records.getContent()){

--- a/src/main/java/com/triprecord/triprecord/user/service/UserService.java
+++ b/src/main/java/com/triprecord/triprecord/user/service/UserService.java
@@ -96,8 +96,7 @@ public class UserService {
     }
 
     public RecordPageResponse getUserRecords(Long userId, Pageable pageable){
-        User user = getUserOrException(userId);
-        Page<Record> records = recordRepository.findAllByCreatedUser(user, pageable);
+        Page<Record> records = recordRepository.findAllByCreatedUser(userId, pageable);
         List<RecordResponse> userRecordGetResponse = new ArrayList<>();
 
         for(Record record : records.getContent()){


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- feat/#87 -> dev
- close #87

## Key Changes
<!-- 최대한 자세히 -->
로그인 한 유저가 작성한 기록 목록들을 조회할 수 있는 API 입니다.
이 점 또한 앞서 기록과 스케줄 목록을 구현한 시원씨와 채은씨의 코드를 바탕으로 구현하였으며, 차이점은 모든 정보가 아닌 유저의 기록만 불러 온다는 것입니다.
![image](https://github.com/Trip-Record/Server/assets/126096318/91cd4367-002d-4724-b668-0e1fe94d1d44)

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->
일정 목록을 불러오는 것과 마찬가지로 DTO를 이전에 쓰던 것을 바탕으로 구현 한 것이다 보니 불필요한 유저 정보까지 들어가게 되었습니다. 스케줄과 동일하게 DTO를 새로 만들게 된다면 다시 수정해서 올리도록 하겠습니다!
## References
<!-- 참고한 자료-->
