### PR TITLE
[FEAT] 기록 댓글 삭제 API

### DIFF
--- a/src/main/java/com/triprecord/triprecord/global/exception/ErrorCode.java
+++ b/src/main/java/com/triprecord/triprecord/global/exception/ErrorCode.java
@@ -21,6 +21,7 @@ public enum ErrorCode {
 
     RECORD_ALREADY_LIKED(HttpStatus.CONFLICT, "이미 좋아요를 남긴 기록입니다."),
     RECORD_LIKE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 기록에 좋아요를 남기지 않았습니다."),
+    RECORD_COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "댓글을 찾을 수 없습니다."),
     INVALID_DATE(HttpStatus.BAD_REQUEST, "기간이 잘못되었습니다."),
     INVALID_RECORD_PLACE_SIZE(HttpStatus.BAD_REQUEST, "기록할 수 있는 최대 장소 수를 초과하였습니다."),
     INVALID_RECORD_IMAGE_SIZE(HttpStatus.BAD_REQUEST, "기록할 수 있는 최대 사진 수를 초과하였습니다."),

--- a/src/main/java/com/triprecord/triprecord/record/controller/RecordController.java
+++ b/src/main/java/com/triprecord/triprecord/record/controller/RecordController.java
@@ -59,6 +59,13 @@ public class RecordController {
         return ResponseEntity.status(HttpStatus.OK).body(new ResponseMessage("기록 수정에 성공했습니다."));
     }
 
+
+    @DeleteMapping("/comments/{recordCommentId}")
+    public ResponseEntity<ResponseMessage> deleteRecordComment(Authentication authentication, @PathVariable Long recordCommentId) {
+        recordService.deleteCommentFromRecord(Long.valueOf(authentication.getName()), recordCommentId);
+        return ResponseEntity.status(HttpStatus.OK).body(new ResponseMessage("기록 댓글 삭제에 성공했습니다."));
+    }
+
     @PostMapping("/{recordId}/likes")
     public ResponseEntity<ResponseMessage> postLike(Authentication authentication, @PathVariable Long recordId){
         recordService.postLikeToRecord(Long.valueOf(authentication.getName()), recordId);

--- a/src/main/java/com/triprecord/triprecord/record/service/RecordCommentService.java
+++ b/src/main/java/com/triprecord/triprecord/record/service/RecordCommentService.java
@@ -1,8 +1,12 @@
 package com.triprecord.triprecord.record.service;
 
 
+import com.triprecord.triprecord.global.exception.ErrorCode;
+import com.triprecord.triprecord.global.exception.TripRecordException;
 import com.triprecord.triprecord.record.entity.Record;
+import com.triprecord.triprecord.record.entity.RecordComment;
 import com.triprecord.triprecord.record.repository.RecordCommentRepository;
+import com.triprecord.triprecord.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -15,5 +19,10 @@ public class RecordCommentService {
 
     public Long getRecordCommentCount(Record record){
         return recordCommentRepository.countByCommentedRecord(record);
+    }
+
+    public RecordComment getRecordCommentOrException(Long recordId) {
+        return recordCommentRepository.findById(recordId).orElseThrow(
+                ()->new TripRecordException(ErrorCode.RECORD_COMMENT_NOT_FOUND));
     }
 }

--- a/src/main/java/com/triprecord/triprecord/record/service/RecordCommentService.java
+++ b/src/main/java/com/triprecord/triprecord/record/service/RecordCommentService.java
@@ -25,4 +25,8 @@ public class RecordCommentService {
         return recordCommentRepository.findById(recordId).orElseThrow(
                 ()->new TripRecordException(ErrorCode.RECORD_COMMENT_NOT_FOUND));
     }
+
+    public void deleteRecordComment(RecordComment comment) {
+        recordCommentRepository.delete(comment);
+    }
 }

--- a/src/main/java/com/triprecord/triprecord/record/service/RecordService.java
+++ b/src/main/java/com/triprecord/triprecord/record/service/RecordService.java
@@ -10,6 +10,7 @@ import com.triprecord.triprecord.record.controller.response.RecordResponse;
 import com.triprecord.triprecord.record.dto.RecordImageData;
 import com.triprecord.triprecord.record.dto.RecordUpdateData;
 import com.triprecord.triprecord.record.entity.Record;
+import com.triprecord.triprecord.record.entity.RecordComment;
 import com.triprecord.triprecord.record.repository.RecordRepository;
 import com.triprecord.triprecord.record.controller.request.RecordCreateRequest;
 import com.triprecord.triprecord.user.service.UserService;
@@ -103,6 +104,16 @@ public class RecordService {
 
         modifyPlace(record, request.deletePlaceIds(), request.addPlaceIds());
         modifyImage(record, request.deleteImages(), request.addImages());
+    }
+
+    @Transactional
+    public void deleteCommentFromRecord(Long userId, Long recordCommentId) {
+        User user = userService.getUserOrException(userId);
+
+        RecordComment comment = recordCommentService.getRecordCommentOrException(recordCommentId);
+        checkSameUser(comment.getCommentedUser(), user);
+
+        recordCommentService.deleteRecordComment(comment);
     }
 
     public void postLikeToRecord(Long userId, Long recordId) {


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- feat/#90 -> dev
- close #90 

## Key Changes
<!-- 최대한 자세히 -->
### 기록에 남긴 댓글을 삭제하는 API
- DELETE /records/comments/{recordCommentId}
- 일치하는 recordCommentId가 없는 경우 에러
- 현재 로그인한 유저와 코멘트 작성 유저와 일치하지 않는 경우 에러

**성공시 (200)**

![image](https://github.com/Trip-Record/Server/assets/105481797/958e6ed6-632a-400d-ac04-d9fcec95b107)

**일치하는 기록 댓글이 없는 경우 (404)** 

![image](https://github.com/Trip-Record/Server/assets/105481797/3fc8e5ea-d325-4d98-afda-6f242f23f5aa)

**로그인 유저가 댓글 작성 유저가 아닌 경우 (401)**

![image](https://github.com/Trip-Record/Server/assets/105481797/7bb13d38-69b7-465e-96c3-e77c0b6e4e82)



## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->
궁금한 점, 개선할 점 등 편하게 의견 주세요~ 😃

## References
<!-- 참고한 자료-->
