### PR TITLE
[FEAT] 일정 댓글 목록 조회 API

### DIFF
--- a/src/main/java/com/triprecord/triprecord/global/config/SecurityConfig.java
+++ b/src/main/java/com/triprecord/triprecord/global/config/SecurityConfig.java
@@ -34,6 +34,7 @@ public class SecurityConfig {
             "/records/{recordId}",
             "/schedules",
             "/schedules/{scheduleId}",
+            "/schedules/{scheduleId}/comments",
             "/trip-styles",
             "/locations"
     };

--- a/src/main/java/com/triprecord/triprecord/global/util/EntityBaseTime.java
+++ b/src/main/java/com/triprecord/triprecord/global/util/EntityBaseTime.java
@@ -5,9 +5,11 @@ import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
 import jakarta.persistence.PrePersist;
 import java.time.LocalDateTime;
+import lombok.Getter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
+@Getter
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
 public abstract class EntityBaseTime {

--- a/src/main/java/com/triprecord/triprecord/schedule/controller/ScheduleController.java
+++ b/src/main/java/com/triprecord/triprecord/schedule/controller/ScheduleController.java
@@ -4,6 +4,7 @@ import com.triprecord.triprecord.global.util.ResponseMessage;
 import com.triprecord.triprecord.schedule.dto.request.ScheduleCommentContentRequest;
 import com.triprecord.triprecord.schedule.dto.request.ScheduleCreateRequest;
 import com.triprecord.triprecord.schedule.dto.request.ScheduleUpdateRequest;
+import com.triprecord.triprecord.schedule.dto.response.ScheduleCommentPageGetResponse;
 import com.triprecord.triprecord.schedule.dto.response.ScheduleGetResponse;
 import com.triprecord.triprecord.schedule.dto.response.SchedulePageGetResponse;
 import com.triprecord.triprecord.schedule.service.ScheduleCommentService;
@@ -54,8 +55,10 @@ public class ScheduleController {
     }
 
     @GetMapping
-    public ResponseEntity<SchedulePageGetResponse> getSchedules(Authentication authentication, @PageableDefault(size = 5) Pageable pageable) {
-        Optional<Long> userId = Optional.ofNullable((authentication == null) ? null : Long.parseLong(authentication.getName()));
+    public ResponseEntity<SchedulePageGetResponse> getSchedules(Authentication authentication,
+                                                                @PageableDefault(size = 5) Pageable pageable) {
+        Optional<Long> userId = Optional.ofNullable(
+                (authentication == null) ? null : Long.parseLong(authentication.getName()));
         SchedulePageGetResponse response = scheduleService.getSchedules(userId, pageable);
         return ResponseEntity
                 .status(HttpStatus.OK)
@@ -63,8 +66,10 @@ public class ScheduleController {
     }
 
     @GetMapping("/{scheduleId}")
-    public ResponseEntity<ScheduleGetResponse> getSchedule(Authentication authentication, @PathVariable Long scheduleId) {
-        Optional<Long> userId = Optional.ofNullable((authentication == null) ? null : Long.parseLong(authentication.getName()));
+    public ResponseEntity<ScheduleGetResponse> getSchedule(Authentication authentication,
+                                                           @PathVariable Long scheduleId) {
+        Optional<Long> userId = Optional.ofNullable(
+                (authentication == null) ? null : Long.parseLong(authentication.getName()));
         ScheduleGetResponse response = scheduleService.getSchedule(userId, scheduleId);
         return ResponseEntity
                 .status(HttpStatus.OK)
@@ -99,6 +104,15 @@ public class ScheduleController {
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(new ResponseMessage("좋아요 등록에 성공했습니다."));
+    }
+
+    @GetMapping("{scheduleId}/comments")
+    public ResponseEntity<ScheduleCommentPageGetResponse> getScheduleComments(@PathVariable Long scheduleId,
+                                                                              @PageableDefault(size = 5) Pageable pageable) {
+        ScheduleCommentPageGetResponse response = scheduleService.getScheduleComments(scheduleId, pageable);
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(response);
     }
 
     @PostMapping("{scheduleId}/comments")

--- a/src/main/java/com/triprecord/triprecord/schedule/dto/response/ScheduleCommentGetResponse.java
+++ b/src/main/java/com/triprecord/triprecord/schedule/dto/response/ScheduleCommentGetResponse.java
@@ -1,0 +1,19 @@
+package com.triprecord.triprecord.schedule.dto.response;
+
+import com.triprecord.triprecord.schedule.entity.ScheduleComment;
+import com.triprecord.triprecord.user.dto.response.UserProfile;
+import java.time.format.DateTimeFormatter;
+
+public record ScheduleCommentGetResponse(
+        UserProfile userProfile,
+        String commentContent,
+        String commentCreatedTime
+) {
+    public static ScheduleCommentGetResponse of(ScheduleComment scheduleComment) {
+        return new ScheduleCommentGetResponse(
+                UserProfile.of(scheduleComment.getCommentedUser()),
+                scheduleComment.getScheduleCommentContent(),
+                scheduleComment.getCreatedTime().format(DateTimeFormatter.ofPattern("yyyy.MM.dd HH:mm"))
+        );
+    }
+}

--- a/src/main/java/com/triprecord/triprecord/schedule/dto/response/ScheduleCommentPageGetResponse.java
+++ b/src/main/java/com/triprecord/triprecord/schedule/dto/response/ScheduleCommentPageGetResponse.java
@@ -1,0 +1,12 @@
+package com.triprecord.triprecord.schedule.dto.response;
+
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record ScheduleCommentPageGetResponse(
+        int totalPages,
+        int pageNumber,
+        List<ScheduleCommentGetResponse> scheduleComments
+) {
+}

--- a/src/main/java/com/triprecord/triprecord/schedule/repository/ScheduleCommentRepository.java
+++ b/src/main/java/com/triprecord/triprecord/schedule/repository/ScheduleCommentRepository.java
@@ -2,6 +2,8 @@ package com.triprecord.triprecord.schedule.repository;
 
 import com.triprecord.triprecord.schedule.entity.Schedule;
 import com.triprecord.triprecord.schedule.entity.ScheduleComment;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -9,4 +11,6 @@ import org.springframework.stereotype.Repository;
 public interface ScheduleCommentRepository extends JpaRepository<ScheduleComment, Long> {
 
     Long countByCommentedSchedule(Schedule schedule);
+
+    Page<ScheduleComment> findAllByCommentedSchedule(Schedule commentedSchedule, Pageable pageable);
 }

--- a/src/main/java/com/triprecord/triprecord/schedule/service/ScheduleCommentService.java
+++ b/src/main/java/com/triprecord/triprecord/schedule/service/ScheduleCommentService.java
@@ -3,12 +3,17 @@ package com.triprecord.triprecord.schedule.service;
 import com.triprecord.triprecord.global.exception.ErrorCode;
 import com.triprecord.triprecord.global.exception.TripRecordException;
 import com.triprecord.triprecord.schedule.dto.request.ScheduleCommentContentRequest;
+import com.triprecord.triprecord.schedule.dto.response.ScheduleCommentGetResponse;
+import com.triprecord.triprecord.schedule.dto.response.ScheduleCommentPageGetResponse;
 import com.triprecord.triprecord.schedule.entity.Schedule;
 import com.triprecord.triprecord.schedule.entity.ScheduleComment;
 import com.triprecord.triprecord.schedule.repository.ScheduleCommentRepository;
 import com.triprecord.triprecord.user.entity.User;
 import com.triprecord.triprecord.user.service.UserService;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -22,6 +27,20 @@ public class ScheduleCommentService {
 
     public Long getScheduleCommentCount(Schedule schedule) {
         return scheduleCommentRepository.countByCommentedSchedule(schedule);
+    }
+
+    public ScheduleCommentPageGetResponse getScheduleComments(Schedule schedule, Pageable pageable) {
+        Page<ScheduleComment> scheduleComments = scheduleCommentRepository.findAllByCommentedSchedule(schedule,
+                pageable);
+        List<ScheduleCommentGetResponse> scheduleGetResponses = scheduleComments.stream()
+                .map(ScheduleCommentGetResponse::of)
+                .toList();
+
+        return ScheduleCommentPageGetResponse.builder()
+                .totalPages(scheduleComments.getTotalPages())
+                .pageNumber(scheduleComments.getNumber())
+                .scheduleComments(scheduleGetResponses)
+                .build();
     }
 
     @Transactional
@@ -47,7 +66,7 @@ public class ScheduleCommentService {
         }
         scheduleComment.updateContent(content);
     }
-  
+
     @Transactional
     public void deleteScheduleComment(Long userId, Long scheduleCommentId) {
         User user = userService.getUserOrException(userId);

--- a/src/main/java/com/triprecord/triprecord/schedule/service/ScheduleService.java
+++ b/src/main/java/com/triprecord/triprecord/schedule/service/ScheduleService.java
@@ -7,6 +7,7 @@ import com.triprecord.triprecord.location.entity.Place;
 import com.triprecord.triprecord.schedule.dto.request.ScheduleCommentContentRequest;
 import com.triprecord.triprecord.schedule.dto.request.ScheduleCreateRequest;
 import com.triprecord.triprecord.schedule.dto.request.ScheduleUpdateRequest;
+import com.triprecord.triprecord.schedule.dto.response.ScheduleCommentPageGetResponse;
 import com.triprecord.triprecord.schedule.dto.response.ScheduleGetResponse;
 import com.triprecord.triprecord.schedule.dto.response.SchedulePageGetResponse;
 import com.triprecord.triprecord.schedule.entity.Schedule;
@@ -127,7 +128,9 @@ public class ScheduleService {
     }
 
     private Boolean findUserScheduleLiked(Optional<Long> userId, Schedule schedule) {
-        if(userId.isPresent()) return scheduleLikeService.findUserLikedSchedule(schedule, userService.getUserOrException(userId.get()));
+        if (userId.isPresent()) {
+            return scheduleLikeService.findUserLikedSchedule(schedule, userService.getUserOrException(userId.get()));
+        }
         return false;
     }
 
@@ -166,6 +169,11 @@ public class ScheduleService {
         User user = userService.getUserOrException(userId);
         Schedule schedule = getScheduleOrException(scheduleId);
         scheduleLikeService.createScheduleLike(user, schedule);
+    }
+
+    public ScheduleCommentPageGetResponse getScheduleComments(Long scheduleId, Pageable pageable) {
+        Schedule schedule = getScheduleOrException(scheduleId);
+        return scheduleCommentService.getScheduleComments(schedule, pageable);
     }
 
     @Transactional


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- feat/#94 -> dev
- close #94

## Key Changes
<!-- 최대한 자세히 -->
### 일정 댓글 목록 조회 API
- SpringSecurity 클래스 내 permitAllPaths 배열에 해당 API 경로 추가

- EntityBaseTime 클래스 내 Getter 추가 -> 일정 댓글 생성 시간(`createdTime`)을 Get 하기 위함

- 나머지는 기존 일정 목록 조회 API와 유사합니당!

- 다른 점이 있다면 해당 API 조회 값은 최신순 조회가 아니라서 레포지토리에서 ORDER BY를 사용하지 않아요!

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->
X

## References
<!-- 참고한 자료-->
X