### PR TITLE
[FEAT] 기록 댓글 수정 API

### DIFF
--- a/src/main/java/com/triprecord/triprecord/global/exception/ErrorCode.java
+++ b/src/main/java/com/triprecord/triprecord/global/exception/ErrorCode.java
@@ -21,6 +21,7 @@ public enum ErrorCode {
 
     RECORD_ALREADY_LIKED(HttpStatus.CONFLICT, "이미 좋아요를 남긴 기록입니다."),
     RECORD_LIKE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 기록에 좋아요를 남기지 않았습니다."),
+    RECORD_COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "댓글을 찾을 수 없습니다."),
     INVALID_DATE(HttpStatus.BAD_REQUEST, "기간이 잘못되었습니다."),
     INVALID_RECORD_PLACE_SIZE(HttpStatus.BAD_REQUEST, "기록할 수 있는 최대 장소 수를 초과하였습니다."),
     INVALID_RECORD_IMAGE_SIZE(HttpStatus.BAD_REQUEST, "기록할 수 있는 최대 사진 수를 초과하였습니다."),

--- a/src/main/java/com/triprecord/triprecord/global/exception/ErrorCode.java
+++ b/src/main/java/com/triprecord/triprecord/global/exception/ErrorCode.java
@@ -22,6 +22,7 @@ public enum ErrorCode {
     RECORD_ALREADY_LIKED(HttpStatus.CONFLICT, "이미 좋아요를 남긴 기록입니다."),
     RECORD_LIKE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 기록에 좋아요를 남기지 않았습니다."),
     RECORD_COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "댓글을 찾을 수 없습니다."),
+    RECORD_COMMENT_DUPLICATE(HttpStatus.CONFLICT, "기존 기록 댓글과 동일합니다."),
     INVALID_DATE(HttpStatus.BAD_REQUEST, "기간이 잘못되었습니다."),
     INVALID_RECORD_PLACE_SIZE(HttpStatus.BAD_REQUEST, "기록할 수 있는 최대 장소 수를 초과하였습니다."),
     INVALID_RECORD_IMAGE_SIZE(HttpStatus.BAD_REQUEST, "기록할 수 있는 최대 사진 수를 초과하였습니다."),

--- a/src/main/java/com/triprecord/triprecord/record/controller/RecordController.java
+++ b/src/main/java/com/triprecord/triprecord/record/controller/RecordController.java
@@ -2,6 +2,7 @@ package com.triprecord.triprecord.record.controller;
 
 
 import com.triprecord.triprecord.global.util.ResponseMessage;
+import com.triprecord.triprecord.record.controller.request.RecordCommentContent;
 import com.triprecord.triprecord.record.controller.request.RecordCreateRequest;
 import com.triprecord.triprecord.record.controller.request.RecordModifyRequest;
 import com.triprecord.triprecord.record.controller.response.RecordPageResponse;
@@ -19,6 +20,7 @@ import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -60,6 +62,14 @@ public class RecordController {
                                                         @Valid RecordModifyRequest request) {
         recordService.modifyRecord(Long.valueOf(authentication.getName()), recordId, request);
         return ResponseEntity.status(HttpStatus.OK).body(new ResponseMessage("기록 수정에 성공했습니다."));
+    }
+
+    @PatchMapping("/comments/{recordCommentId}")
+    public ResponseEntity<ResponseMessage> modifyRecordComment(Authentication authentication,
+                                                               @PathVariable Long recordCommentId,
+                                                               @RequestBody @Valid RecordCommentContent request) {
+        recordService.modifyRecordComment(Long.valueOf(authentication.getName()), recordCommentId, request.commentContent());
+        return ResponseEntity.status(HttpStatus.OK).body(new ResponseMessage("댓글 수정에 성공했습니다."));
     }
 
     @PostMapping("/{recordId}/likes")

--- a/src/main/java/com/triprecord/triprecord/record/entity/RecordComment.java
+++ b/src/main/java/com/triprecord/triprecord/record/entity/RecordComment.java
@@ -40,4 +40,8 @@ public class RecordComment extends EntityBaseTime {
         this.commentedRecord = record;
         this.commentedUser = user;
     }
+
+    public void updateContent(String newContent) {
+        this.commentContent = newContent;
+    }
 }

--- a/src/main/java/com/triprecord/triprecord/record/service/RecordCommentService.java
+++ b/src/main/java/com/triprecord/triprecord/record/service/RecordCommentService.java
@@ -1,8 +1,12 @@
 package com.triprecord.triprecord.record.service;
 
 
+import com.triprecord.triprecord.global.exception.ErrorCode;
+import com.triprecord.triprecord.global.exception.TripRecordException;
 import com.triprecord.triprecord.record.entity.Record;
+import com.triprecord.triprecord.record.entity.RecordComment;
 import com.triprecord.triprecord.record.repository.RecordCommentRepository;
+import com.triprecord.triprecord.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -15,5 +19,10 @@ public class RecordCommentService {
 
     public Long getRecordCommentCount(Record record){
         return recordCommentRepository.countByCommentedRecord(record);
+    }
+
+    public RecordComment getRecordCommentOrException(Long recordId) {
+        return recordCommentRepository.findById(recordId).orElseThrow(
+                ()->new TripRecordException(ErrorCode.RECORD_COMMENT_NOT_FOUND));
     }
 }

--- a/src/main/java/com/triprecord/triprecord/record/service/RecordCommentService.java
+++ b/src/main/java/com/triprecord/triprecord/record/service/RecordCommentService.java
@@ -27,6 +27,9 @@ public class RecordCommentService {
     }
 
     public void updateRecordComment(RecordComment comment, String newContent) {
+        if(comment.getCommentContent().equals(newContent)) {
+            throw new TripRecordException(ErrorCode.RECORD_COMMENT_DUPLICATE);
+        }
         comment.updateContent(newContent);
     }
 }

--- a/src/main/java/com/triprecord/triprecord/record/service/RecordCommentService.java
+++ b/src/main/java/com/triprecord/triprecord/record/service/RecordCommentService.java
@@ -25,4 +25,8 @@ public class RecordCommentService {
         return recordCommentRepository.findById(recordId).orElseThrow(
                 ()->new TripRecordException(ErrorCode.RECORD_COMMENT_NOT_FOUND));
     }
+
+    public void updateRecordComment(RecordComment comment, String newContent) {
+        comment.updateContent(newContent);
+    }
 }

--- a/src/main/java/com/triprecord/triprecord/record/service/RecordService.java
+++ b/src/main/java/com/triprecord/triprecord/record/service/RecordService.java
@@ -10,6 +10,7 @@ import com.triprecord.triprecord.record.controller.response.RecordResponse;
 import com.triprecord.triprecord.record.dto.RecordImageData;
 import com.triprecord.triprecord.record.dto.RecordUpdateData;
 import com.triprecord.triprecord.record.entity.Record;
+import com.triprecord.triprecord.record.entity.RecordComment;
 import com.triprecord.triprecord.record.repository.RecordRepository;
 import com.triprecord.triprecord.record.controller.request.RecordCreateRequest;
 import com.triprecord.triprecord.user.service.UserService;
@@ -112,6 +113,15 @@ public class RecordService {
 
         modifyPlace(record, request.deletePlaceIds(), request.addPlaceIds());
         modifyImage(record, request.deleteImages(), request.addImages());
+    }
+
+    @Transactional
+    public void modifyRecordComment(Long userId, Long recordId, String content) {
+        User user = userService.getUserOrException(userId);
+        RecordComment comment = recordCommentService.getRecordCommentOrException(recordId);
+        checkSameUser(comment.getCommentedUser(), user);
+
+        recordCommentService.updateRecordComment(comment, content);
     }
 
     public void postLikeToRecord(Long userId, Long recordId) {


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- feat/#91 -> dev
- close #91 

## Key Changes
<!-- 최대한 자세히 -->
### 기록에 남긴 댓글을 수정하는 API
- PATCH /records/comments/{recordCommentId}
- 일치하는 기록 댓글이 없으면 에러
- 현재 로그인한 유저가 댓글 작성 유저가 아닐 경우 에러
- 수정 요청 내용이 이전 댓글 내용과 같다면 에러

**성공시 (200)**

![image](https://github.com/Trip-Record/Server/assets/105481797/e9c39039-59e1-430f-856a-165bb7dce58a)

**로그인 유저가 댓글 작성 유저가 아닌 경우 (401)**

![image](https://github.com/Trip-Record/Server/assets/105481797/719eea98-0ebe-46eb-abd4-987ac2fd04ee)

**이전 내용과 동일한 경우 (409)**

![image](https://github.com/Trip-Record/Server/assets/105481797/6ba6d93a-65c0-4402-801a-c3d7893002b5)


## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->
궁금한 점, 개선할 점 등 편하게 의견 주세요~ 😃

## References
<!-- 참고한 자료-->
