### PR TITLE
[FEAT] 기록 댓글 목록 조회 API

### DIFF
--- a/src/main/java/com/triprecord/triprecord/global/config/SecurityConfig.java
+++ b/src/main/java/com/triprecord/triprecord/global/config/SecurityConfig.java
@@ -32,6 +32,7 @@ public class SecurityConfig {
             "/ranks/seasons",
             "/records",
             "/records/{recordId}",
+            "/records/{recordId}/comments",
             "/schedules",
             "/schedules/{scheduleId}",
             "/schedules/{scheduleId}/comments",

--- a/src/main/java/com/triprecord/triprecord/global/util/Formatter.java
+++ b/src/main/java/com/triprecord/triprecord/global/util/Formatter.java
@@ -1,0 +1,13 @@
+package com.triprecord.triprecord.global.util;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+
+public class Formatter {
+
+    public static String getDateTime(LocalDateTime dateTime) {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy.MM.dd HH:mm");
+        return dateTime.format(formatter);
+    }
+}

--- a/src/main/java/com/triprecord/triprecord/record/controller/RecordController.java
+++ b/src/main/java/com/triprecord/triprecord/record/controller/RecordController.java
@@ -78,18 +78,18 @@ public class RecordController {
         return ResponseEntity.status(HttpStatus.CREATED).body(new ResponseMessage("댓글 전송에 성공했습니다."));
     }
 
-    @DeleteMapping("/comments/{recordCommentId}")
-    public ResponseEntity<ResponseMessage> deleteRecordComment(Authentication authentication, @PathVariable Long recordCommentId) {
-        recordService.deleteCommentFromRecord(Long.valueOf(authentication.getName()), recordCommentId);
-        return ResponseEntity.status(HttpStatus.OK).body(new ResponseMessage("기록 댓글 삭제에 성공했습니다."));
-    }
-
     @PatchMapping("/comments/{recordCommentId}")
     public ResponseEntity<ResponseMessage> modifyRecordComment(Authentication authentication,
                                                                @PathVariable Long recordCommentId,
                                                                @RequestBody @Valid RecordCommentContent request) {
         recordService.modifyRecordComment(Long.valueOf(authentication.getName()), recordCommentId, request.commentContent());
         return ResponseEntity.status(HttpStatus.OK).body(new ResponseMessage("댓글 수정에 성공했습니다."));
+    }
+
+    @DeleteMapping("/comments/{recordCommentId}")
+    public ResponseEntity<ResponseMessage> deleteRecordComment(Authentication authentication, @PathVariable Long recordCommentId) {
+        recordService.deleteCommentFromRecord(Long.valueOf(authentication.getName()), recordCommentId);
+        return ResponseEntity.status(HttpStatus.OK).body(new ResponseMessage("기록 댓글 삭제에 성공했습니다."));
     }
 
     @PostMapping("/{recordId}/likes")

--- a/src/main/java/com/triprecord/triprecord/record/controller/RecordController.java
+++ b/src/main/java/com/triprecord/triprecord/record/controller/RecordController.java
@@ -13,6 +13,7 @@ import jakarta.validation.Valid;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
@@ -66,7 +67,8 @@ public class RecordController {
     }
 
     @GetMapping("/{recordId}/comments")
-    public ResponseEntity<RecordCommentPage> getCommentPage(Pageable pageable, @PathVariable Long recordId) {
+    public ResponseEntity<RecordCommentPage> getCommentPage(@PageableDefault(size = 5) Pageable pageable,
+                                                            @PathVariable Long recordId) {
         return ResponseEntity.status(HttpStatus.OK).body(recordService.getRecordComments(recordId, pageable));
     }
   

--- a/src/main/java/com/triprecord/triprecord/record/controller/RecordController.java
+++ b/src/main/java/com/triprecord/triprecord/record/controller/RecordController.java
@@ -5,6 +5,7 @@ import com.triprecord.triprecord.global.util.ResponseMessage;
 import com.triprecord.triprecord.record.controller.request.RecordCommentContent;
 import com.triprecord.triprecord.record.controller.request.RecordCreateRequest;
 import com.triprecord.triprecord.record.controller.request.RecordModifyRequest;
+import com.triprecord.triprecord.record.controller.response.RecordCommentPage;
 import com.triprecord.triprecord.record.controller.response.RecordPageResponse;
 import com.triprecord.triprecord.record.controller.response.RecordResponse;
 import com.triprecord.triprecord.record.service.RecordService;
@@ -62,6 +63,11 @@ public class RecordController {
                                                         @Valid RecordModifyRequest request) {
         recordService.modifyRecord(Long.valueOf(authentication.getName()), recordId, request);
         return ResponseEntity.status(HttpStatus.OK).body(new ResponseMessage("기록 수정에 성공했습니다."));
+    }
+
+    @GetMapping("/{recordId}/comments")
+    public ResponseEntity<RecordCommentPage> getCommentPage(Pageable pageable, @PathVariable Long recordId) {
+        return ResponseEntity.status(HttpStatus.OK).body(recordService.getRecordComments(recordId, pageable));
     }
   
     @PostMapping("/{recordId}/comments")

--- a/src/main/java/com/triprecord/triprecord/record/controller/response/RecordCommentPage.java
+++ b/src/main/java/com/triprecord/triprecord/record/controller/response/RecordCommentPage.java
@@ -1,0 +1,13 @@
+package com.triprecord.triprecord.record.controller.response;
+
+import com.triprecord.triprecord.record.dto.RecordCommentData;
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record RecordCommentPage(
+        int totalPages,
+        int pageNumber,
+        List<RecordCommentData> recordComments
+) {
+}

--- a/src/main/java/com/triprecord/triprecord/record/dto/RecordCommentData.java
+++ b/src/main/java/com/triprecord/triprecord/record/dto/RecordCommentData.java
@@ -1,0 +1,21 @@
+package com.triprecord.triprecord.record.dto;
+
+import static com.triprecord.triprecord.global.util.Formatter.getDateTime;
+
+import com.triprecord.triprecord.record.entity.RecordComment;
+import com.triprecord.triprecord.user.dto.response.UserProfile;
+
+public record RecordCommentData(
+        UserProfile userProfile,
+        String commentContent,
+        String commentCreatedTime
+) {
+
+    public static RecordCommentData fromEntity(RecordComment recordComment) {
+        return new RecordCommentData(
+                UserProfile.of(recordComment.getCommentedUser()),
+                recordComment.getCommentContent(),
+                getDateTime(recordComment.getCreatedTime())
+        );
+    }
+}

--- a/src/main/java/com/triprecord/triprecord/record/repository/RecordCommentRepository.java
+++ b/src/main/java/com/triprecord/triprecord/record/repository/RecordCommentRepository.java
@@ -2,6 +2,8 @@ package com.triprecord.triprecord.record.repository;
 
 import com.triprecord.triprecord.record.entity.Record;
 import com.triprecord.triprecord.record.entity.RecordComment;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -10,4 +12,6 @@ import org.springframework.stereotype.Repository;
 public interface RecordCommentRepository extends JpaRepository<RecordComment, Long> {
 
     Long countByCommentedRecord(Record record);
+
+    Page<RecordComment> findAllByCommentedRecord(Record commentedRecord, Pageable pageable);
 }

--- a/src/main/java/com/triprecord/triprecord/record/service/RecordCommentService.java
+++ b/src/main/java/com/triprecord/triprecord/record/service/RecordCommentService.java
@@ -3,11 +3,16 @@ package com.triprecord.triprecord.record.service;
 
 import com.triprecord.triprecord.global.exception.ErrorCode;
 import com.triprecord.triprecord.global.exception.TripRecordException;
+import com.triprecord.triprecord.record.controller.response.RecordCommentPage;
+import com.triprecord.triprecord.record.dto.RecordCommentData;
 import com.triprecord.triprecord.record.entity.Record;
 import com.triprecord.triprecord.record.entity.RecordComment;
 import com.triprecord.triprecord.record.repository.RecordCommentRepository;
 import com.triprecord.triprecord.user.entity.User;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -23,6 +28,17 @@ public class RecordCommentService {
     public RecordComment getRecordCommentOrException(Long recordId) {
         return recordCommentRepository.findById(recordId).orElseThrow(
                 ()->new TripRecordException(ErrorCode.RECORD_COMMENT_NOT_FOUND));
+    }
+
+    public RecordCommentPage getRecordComments(Record record, Pageable pageable) {
+        Page<RecordComment> comments = recordCommentRepository.findAllByCommentedRecord(record, pageable);
+        List<RecordCommentData> commentData = comments.map(RecordCommentData::fromEntity).toList();
+
+        return RecordCommentPage.builder()
+                .totalPages(comments.getTotalPages())
+                .pageNumber(comments.getNumber())
+                .recordComments(commentData)
+                .build();
     }
 
     public void createRecordComment(User user, Record record, String content) {

--- a/src/main/java/com/triprecord/triprecord/record/service/RecordService.java
+++ b/src/main/java/com/triprecord/triprecord/record/service/RecordService.java
@@ -130,15 +130,6 @@ public class RecordService {
         recordCommentService.createRecordComment(user, record, content);
     }
 
-    @Transactional
-    public void deleteCommentFromRecord(Long userId, Long recordCommentId) {
-        User user = userService.getUserOrException(userId);
-
-        RecordComment comment = recordCommentService.getRecordCommentOrException(recordCommentId);
-        checkSameUser(comment.getCommentedUser(), user);
-
-        recordCommentService.deleteRecordComment(comment);
-    }
 
     @Transactional
     public void modifyRecordComment(Long userId, Long recordId, String content) {
@@ -147,6 +138,16 @@ public class RecordService {
         checkSameUser(comment.getCommentedUser(), user);
 
         recordCommentService.updateRecordComment(comment, content);
+    }
+
+    @Transactional
+    public void deleteCommentFromRecord(Long userId, Long recordCommentId) {
+        User user = userService.getUserOrException(userId);
+
+        RecordComment comment = recordCommentService.getRecordCommentOrException(recordCommentId);
+        checkSameUser(comment.getCommentedUser(), user);
+
+        recordCommentService.deleteRecordComment(comment);
     }
 
     public void postLikeToRecord(Long userId, Long recordId) {

--- a/src/main/java/com/triprecord/triprecord/record/service/RecordService.java
+++ b/src/main/java/com/triprecord/triprecord/record/service/RecordService.java
@@ -5,6 +5,7 @@ import com.triprecord.triprecord.global.exception.ErrorCode;
 import com.triprecord.triprecord.global.exception.TripRecordException;
 import com.triprecord.triprecord.location.dto.PlaceBasicData;
 import com.triprecord.triprecord.record.controller.request.RecordModifyRequest;
+import com.triprecord.triprecord.record.controller.response.RecordCommentPage;
 import com.triprecord.triprecord.record.controller.response.RecordPageResponse;
 import com.triprecord.triprecord.record.controller.response.RecordResponse;
 import com.triprecord.triprecord.record.dto.RecordImageData;
@@ -113,6 +114,13 @@ public class RecordService {
 
         modifyPlace(record, request.deletePlaceIds(), request.addPlaceIds());
         modifyImage(record, request.deleteImages(), request.addImages());
+    }
+
+    @Transactional(readOnly = true)
+    public RecordCommentPage getRecordComments(Long recordId, Pageable pageable) {
+        Record record = getRecordOrException(recordId);
+
+        return recordCommentService.getRecordComments(record, pageable);
     }
   
     @Transactional

--- a/src/main/java/com/triprecord/triprecord/schedule/dto/response/ScheduleCommentGetResponse.java
+++ b/src/main/java/com/triprecord/triprecord/schedule/dto/response/ScheduleCommentGetResponse.java
@@ -1,5 +1,7 @@
 package com.triprecord.triprecord.schedule.dto.response;
 
+import static com.triprecord.triprecord.global.util.Formatter.getDateTime;
+
 import com.triprecord.triprecord.schedule.entity.ScheduleComment;
 import com.triprecord.triprecord.user.dto.response.UserProfile;
 import java.time.format.DateTimeFormatter;
@@ -13,7 +15,7 @@ public record ScheduleCommentGetResponse(
         return new ScheduleCommentGetResponse(
                 UserProfile.of(scheduleComment.getCommentedUser()),
                 scheduleComment.getScheduleCommentContent(),
-                scheduleComment.getCreatedTime().format(DateTimeFormatter.ofPattern("yyyy.MM.dd HH:mm"))
+                getDateTime(scheduleComment.getCreatedTime())
         );
     }
 }


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- feat/#92 -> dev
- close #92 

## Key Changes
<!-- 최대한 자세히 -->
### 기록에 남겨진 댓글 목록을 조회하는 API
- GET /records/{recordId}/comments
- SpringSecurity 클래스 내 permitAllPaths 배열에 해당 API 경로 추가
- 이전 #96 에 리뷰로 작성한 생성 시간 포멧 클래스 적용에 따른 변경이 포함됨

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->
이전에 개발했던 업데이트, 삭제 메서드의 위치를 수정해서, 해당 변경사항도 포함되어 있습니다 죄송합니다 😭
궁금한 점, 개선할 점 등 편하게 의견 주세요 ~!😃
## References
<!-- 참고한 자료-->
