### PR TITLE
[FIX] 기록 수정 시의 이미지 삭제 방식 변경

### DIFF
--- a/src/main/java/com/triprecord/triprecord/record/controller/request/RecordModifyRequest.java
+++ b/src/main/java/com/triprecord/triprecord/record/controller/request/RecordModifyRequest.java
@@ -16,7 +16,7 @@ public record RecordModifyRequest(
         LocalDate changedEndDate,
         @Size(max = 3) List<Long> deletePlaceIds,
         @Size(max = 3) List<Long> addPlaceIds,
-        @Size(max = 10) List<String> deleteImages,
+        @Size(max = 10) List<Long> deleteImages,
         @Size(max = 10) List<MultipartFile> addImages
 ) {
 }

--- a/src/main/java/com/triprecord/triprecord/record/service/RecordImageService.java
+++ b/src/main/java/com/triprecord/triprecord/record/service/RecordImageService.java
@@ -73,8 +73,8 @@ public class RecordImageService {
     }
 
 
-    private RecordImage getRecordImageOrException(Long imageURL){
-        return recordImageRepository.findById(imageURL).orElseThrow(()->
+    private RecordImage getRecordImageOrException(Long recordImageId){
+        return recordImageRepository.findById(recordImageId).orElseThrow(()->
                 new TripRecordException(ErrorCode.IMAGE_NOT_FOUND));
     }
 

--- a/src/main/java/com/triprecord/triprecord/record/service/RecordService.java
+++ b/src/main/java/com/triprecord/triprecord/record/service/RecordService.java
@@ -179,10 +179,10 @@ public class RecordService {
         recordPlaceService.createRecordPlaces(record, addPlaceIds);
     }
 
-    private void modifyImage(Record record, List<String> deleteImages, List<MultipartFile> addImages){
+    private void modifyImage(Record record, List<Long> deleteImages, List<MultipartFile> addImages){
         if(deleteImages==null && addImages==null) return;
         recordImageService.checkImageSizeValid(record, deleteImages, addImages);
-        recordImageService.deleteRecordImages(record, deleteImages);
+        recordImageService.deleteRecordImages(deleteImages);
         recordImageService.createRecordImages(record, addImages);
     }
 


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- feat/#52 -> dev
- close #52 

## Key Changes
<!-- 최대한 자세히 -->
### 기록을 수정하는 API에서 이미지를 삭제하는 경우의 방식 변경
기존, **이미지 url을 받아 삭제**하는 방식을 
기록에 포함된 **이미지 id를 받아 삭제**하도록 변경했습니다.

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->
- 변경사항에 대해서, 프론트 분들에게도 제가 얘기를 해야 될 것 같습니다!😅
- 궁금한 점이나 개선할 점 등 편하게 의견주세요~

## References
<!-- 참고한 자료-->
