### PR TITLE
[FIX] 일정 수정 API 로직 변경 

### DIFF
--- a/src/main/java/com/triprecord/triprecord/schedule/entity/ScheduleDetail.java
+++ b/src/main/java/com/triprecord/triprecord/schedule/entity/ScheduleDetail.java
@@ -8,12 +8,11 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import java.time.LocalDate;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.time.LocalDate;
 
 @Entity
 @Getter
@@ -41,8 +40,6 @@ public class ScheduleDetail {
     }
 
     public void updateScheduleDetail(ScheduleDetailUpdateRequest updateRequest) {
-        if (!updateRequest.scheduleDetailContent().isBlank()) {
-            this.scheduleContent = updateRequest.scheduleDetailContent();
-        }
+        this.scheduleContent = updateRequest.scheduleDetailContent();
     }
 }

--- a/src/main/java/com/triprecord/triprecord/schedule/service/ScheduleDetailService.java
+++ b/src/main/java/com/triprecord/triprecord/schedule/service/ScheduleDetailService.java
@@ -7,12 +7,11 @@ import com.triprecord.triprecord.schedule.dto.request.ScheduleUpdateRequest;
 import com.triprecord.triprecord.schedule.entity.Schedule;
 import com.triprecord.triprecord.schedule.entity.ScheduleDetail;
 import com.triprecord.triprecord.schedule.repository.ScheduleDetailRepository;
+import java.time.LocalDate;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.time.LocalDate;
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -37,23 +36,34 @@ public class ScheduleDetailService {
 
     @Transactional
     public void updateScheduleDetail(Schedule schedule, ScheduleUpdateRequest scheduleRequest) {
-        if (scheduleRequest.scheduleDetails() == null || scheduleRequest.scheduleDetails().isEmpty()) return;
+        if (scheduleRequest.scheduleDetails() == null || scheduleRequest.scheduleDetails().isEmpty()) {
+            return;
+        }
 
-        List<LocalDate> registeredScheduleDetailDates = scheduleDetailRepository.findScheduleDetailDatesBySchedule(schedule);
+        List<LocalDate> registeredScheduleDetailDates = scheduleDetailRepository.findScheduleDetailDatesBySchedule(
+                schedule);
 
         if (registeredScheduleDetailDates.isEmpty()) { // 기존 저장된 세부 일정이 없는 경우
             scheduleRequest.scheduleDetails().stream()
-                    .forEach(scheduleDetailRequest -> createScheduleDetail(schedule, scheduleDetailRequest.scheduleDetailDate(), scheduleDetailRequest.scheduleDetailContent()));
+                    .forEach(scheduleDetailRequest -> createScheduleDetail(schedule,
+                            scheduleDetailRequest.scheduleDetailDate(), scheduleDetailRequest.scheduleDetailContent()));
         } else {
             // 수정된 일정 기간 내에 포함되지 않는 기존 세부 일정 삭제
             deleteNonIncludedScheduleDetails(schedule, scheduleRequest, registeredScheduleDetailDates);
 
             for (ScheduleDetailUpdateRequest scheduleDetailRequest : scheduleRequest.scheduleDetails()) {
-                if (registeredScheduleDetailDates.contains(scheduleDetailRequest.scheduleDetailDate())) { // 해당 일자 세부 일정이 이미 존재하는 경우 수정
-                    ScheduleDetail scheduleDetail = scheduleDetailRepository.findByScheduleDetailDateAndLinkedSchedule(scheduleDetailRequest.scheduleDetailDate(), schedule);
-                    scheduleDetail.updateScheduleDetail(scheduleDetailRequest);
+                if (registeredScheduleDetailDates.contains(
+                        scheduleDetailRequest.scheduleDetailDate())) { // 해당 일자 세부 일정이 이미 존재하는 경우 수정
+                    ScheduleDetail scheduleDetail = scheduleDetailRepository.findByScheduleDetailDateAndLinkedSchedule(
+                            scheduleDetailRequest.scheduleDetailDate(), schedule);
+                    if (scheduleDetailRequest.scheduleDetailContent().isBlank()) { // 세부 일정 내용이 빈 문자열일 경우 삭제
+                        scheduleDetailRepository.delete(scheduleDetail);
+                    } else {
+                        scheduleDetail.updateScheduleDetail(scheduleDetailRequest);
+                    }
                 } else { // 해당 일자 세부 일정이 존재하지 않는 경우 새로 생성
-                    createScheduleDetail(schedule, scheduleDetailRequest.scheduleDetailDate(), scheduleDetailRequest.scheduleDetailContent());
+                    createScheduleDetail(schedule, scheduleDetailRequest.scheduleDetailDate(),
+                            scheduleDetailRequest.scheduleDetailContent());
                 }
             }
         }
@@ -64,12 +74,15 @@ public class ScheduleDetailService {
                 || !(dateToCheck.isEqual(endDate) || dateToCheck.isBefore(endDate));
     }
 
-    private void deleteNonIncludedScheduleDetails(Schedule schedule, ScheduleUpdateRequest scheduleRequest, List<LocalDate> registeredScheduleDetailDates) {
+    private void deleteNonIncludedScheduleDetails(Schedule schedule, ScheduleUpdateRequest scheduleRequest,
+                                                  List<LocalDate> registeredScheduleDetailDates) {
         registeredScheduleDetailDates.stream()
                 .filter(date -> isNotBetweenInclusive(
                         date,
-                        scheduleRequest.scheduleStartDate() == null ? schedule.getScheduleStartDate() : scheduleRequest.scheduleStartDate(),
-                        scheduleRequest.scheduleStartDate() == null ? schedule.getScheduleEndDate() : scheduleRequest.scheduleEndDate()
+                        scheduleRequest.scheduleStartDate() == null ? schedule.getScheduleStartDate()
+                                : scheduleRequest.scheduleStartDate(),
+                        scheduleRequest.scheduleStartDate() == null ? schedule.getScheduleEndDate()
+                                : scheduleRequest.scheduleEndDate()
                 ))
                 .forEach(date -> scheduleDetailRepository.deleteByScheduleDetailDateAndLinkedSchedule(date, schedule));
     }


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- fix/#105 -> dev
- close #105

## Key Changes
<!-- 최대한 자세히 -->
일정 수정 API 내 세부 일정 수정 로직을 변경했습니다.
DB에 저장되어 있던 세부 일정의 내용을 지운 뒤, 일정 수정 API를 요청할 경우,

**기존** : 세부 일정이 수정 혹은 삭제되지 않음 (DB내 변화가 없음)
**변경 후** : 내용을 지운 세부 일정이 삭제됨

프론트와 협의한 내용에 따라 해당 API에서 세부 일정 내용이 빈 문자열로 요청될 경우 해당 세부 일정이 삭제되도록 구현했습니다.

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->
또, 노트북 운영체제 변경으로 인해,, 수정하지 않은 부분도 변경사항으로 체킹이 되는 불상사가 벌어졌는데요,,
실제 변경한 부분은 ScheduleDetail 클래스와, ScheduleDetailService 59~63 라인만 수정했습니다!

## References
<!-- 참고한 자료-->
X