### PR TITLE
[FIX] 일정, 일정 댓글 생성 유저 판별 응답값 추가

### DIFF
--- a/src/main/java/com/triprecord/triprecord/schedule/controller/ScheduleController.java
+++ b/src/main/java/com/triprecord/triprecord/schedule/controller/ScheduleController.java
@@ -112,9 +112,13 @@ public class ScheduleController {
     }
 
     @GetMapping("{scheduleId}/comments")
-    public ResponseEntity<ScheduleCommentPageGetResponse> getScheduleComments(@PathVariable Long scheduleId,
+    public ResponseEntity<ScheduleCommentPageGetResponse> getScheduleComments(Authentication authentication,
+                                                                              @PathVariable Long scheduleId,
                                                                               @PageableDefault(size = 5) Pageable pageable) {
-        ScheduleCommentPageGetResponse response = scheduleService.getScheduleComments(scheduleId, pageable);
+        Optional<User> user = Optional.ofNullable(
+                (authentication == null) ? null
+                        : userService.getUserOrException(Long.parseLong(authentication.getName())));
+        ScheduleCommentPageGetResponse response = scheduleService.getScheduleComments(user, scheduleId, pageable);
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(response);

--- a/src/main/java/com/triprecord/triprecord/schedule/dto/response/ScheduleCommentGetResponse.java
+++ b/src/main/java/com/triprecord/triprecord/schedule/dto/response/ScheduleCommentGetResponse.java
@@ -4,18 +4,19 @@ import static com.triprecord.triprecord.global.util.Formatter.getDateTime;
 
 import com.triprecord.triprecord.schedule.entity.ScheduleComment;
 import com.triprecord.triprecord.user.dto.response.UserProfile;
-import java.time.format.DateTimeFormatter;
 
 public record ScheduleCommentGetResponse(
         UserProfile userProfile,
         String commentContent,
-        String commentCreatedTime
+        String commentCreatedTime,
+        Boolean isUserCreated
 ) {
-    public static ScheduleCommentGetResponse of(ScheduleComment scheduleComment) {
+    public static ScheduleCommentGetResponse of(ScheduleComment scheduleComment, boolean isUserCreated) {
         return new ScheduleCommentGetResponse(
                 UserProfile.of(scheduleComment.getCommentedUser()),
                 scheduleComment.getScheduleCommentContent(),
-                getDateTime(scheduleComment.getCreatedTime())
+                getDateTime(scheduleComment.getCreatedTime()),
+                isUserCreated
         );
     }
 }

--- a/src/main/java/com/triprecord/triprecord/schedule/dto/response/ScheduleCommentGetResponse.java
+++ b/src/main/java/com/triprecord/triprecord/schedule/dto/response/ScheduleCommentGetResponse.java
@@ -9,7 +9,7 @@ public record ScheduleCommentGetResponse(
         UserProfile userProfile,
         String commentContent,
         String commentCreatedTime,
-        Boolean isUserCreated
+        boolean isUserCreated
 ) {
     public static ScheduleCommentGetResponse of(ScheduleComment scheduleComment, boolean isUserCreated) {
         return new ScheduleCommentGetResponse(

--- a/src/main/java/com/triprecord/triprecord/schedule/dto/response/ScheduleGetResponse.java
+++ b/src/main/java/com/triprecord/triprecord/schedule/dto/response/ScheduleGetResponse.java
@@ -5,7 +5,6 @@ import com.triprecord.triprecord.schedule.entity.ScheduleDetail;
 import com.triprecord.triprecord.schedule.entity.SchedulePlace;
 import com.triprecord.triprecord.user.dto.response.UserProfile;
 import com.triprecord.triprecord.user.entity.User;
-
 import java.util.List;
 
 public record ScheduleGetResponse(
@@ -16,6 +15,7 @@ public record ScheduleGetResponse(
         String scheduleStartDate,
         String scheduleEndDate,
         List<ScheduleDetailGetResponse> scheduleDetails,
+        Boolean isUserCreated,
         Boolean isUserLiked,
         Long scheduleLikeCount,
         Long scheduleCommentCount
@@ -24,6 +24,7 @@ public record ScheduleGetResponse(
                                          Schedule schedule,
                                          List<SchedulePlace> schedulePlaces,
                                          List<ScheduleDetail> scheduleDetails,
+                                         Boolean userCreated,
                                          Boolean userLiked,
                                          Long scheduleLikeCount,
                                          Long scheduleCommentCount) {
@@ -39,6 +40,7 @@ public record ScheduleGetResponse(
                 scheduleDetails.stream()
                         .map(ScheduleDetailGetResponse::of)
                         .toList(),
+                userCreated,
                 userLiked,
                 scheduleLikeCount,
                 scheduleCommentCount

--- a/src/main/java/com/triprecord/triprecord/schedule/dto/response/ScheduleGetResponse.java
+++ b/src/main/java/com/triprecord/triprecord/schedule/dto/response/ScheduleGetResponse.java
@@ -15,8 +15,8 @@ public record ScheduleGetResponse(
         String scheduleStartDate,
         String scheduleEndDate,
         List<ScheduleDetailGetResponse> scheduleDetails,
-        Boolean isUserCreated,
-        Boolean isUserLiked,
+        boolean isUserCreated,
+        boolean isUserLiked,
         Long scheduleLikeCount,
         Long scheduleCommentCount
 ) {
@@ -24,8 +24,8 @@ public record ScheduleGetResponse(
                                          Schedule schedule,
                                          List<SchedulePlace> schedulePlaces,
                                          List<ScheduleDetail> scheduleDetails,
-                                         Boolean userCreated,
-                                         Boolean userLiked,
+                                         boolean isUserCreated,
+                                         boolean isUserLiked,
                                          Long scheduleLikeCount,
                                          Long scheduleCommentCount) {
         return new ScheduleGetResponse(
@@ -40,8 +40,8 @@ public record ScheduleGetResponse(
                 scheduleDetails.stream()
                         .map(ScheduleDetailGetResponse::of)
                         .toList(),
-                userCreated,
-                userLiked,
+                isUserCreated,
+                isUserLiked,
                 scheduleLikeCount,
                 scheduleCommentCount
         );

--- a/src/main/java/com/triprecord/triprecord/schedule/service/ScheduleCommentService.java
+++ b/src/main/java/com/triprecord/triprecord/schedule/service/ScheduleCommentService.java
@@ -35,10 +35,7 @@ public class ScheduleCommentService {
                 pageable);
         List<ScheduleCommentGetResponse> scheduleGetResponses = new ArrayList<>();
         for (ScheduleComment scheduleComment : scheduleComments.getContent()) {
-            boolean isUserCreated = false;
-            if (user.isPresent()) {
-                isUserCreated = scheduleComment.getCommentedUser() == user.get();
-            }
+            boolean isUserCreated = isScheduleCommentCreated(user, scheduleComment);
             scheduleGetResponses.add(ScheduleCommentGetResponse.of(scheduleComment, isUserCreated));
         }
 
@@ -84,6 +81,10 @@ public class ScheduleCommentService {
     public ScheduleComment getScheduleCommentOrException(Long scheduleCommentId) {
         return scheduleCommentRepository.findById(scheduleCommentId).orElseThrow(() ->
                 new TripRecordException(ErrorCode.SCHEDULE_COMMENT_NOT_FOUND));
+    }
+
+    private boolean isScheduleCommentCreated(Optional<User> user, ScheduleComment scheduleComment) {
+        return user.filter(value -> value == scheduleComment.getCommentedUser()).isPresent();
     }
 
 }

--- a/src/main/java/com/triprecord/triprecord/schedule/service/ScheduleCommentService.java
+++ b/src/main/java/com/triprecord/triprecord/schedule/service/ScheduleCommentService.java
@@ -9,7 +9,9 @@ import com.triprecord.triprecord.schedule.entity.Schedule;
 import com.triprecord.triprecord.schedule.entity.ScheduleComment;
 import com.triprecord.triprecord.schedule.repository.ScheduleCommentRepository;
 import com.triprecord.triprecord.user.entity.User;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -27,12 +29,18 @@ public class ScheduleCommentService {
         return scheduleCommentRepository.countByCommentedSchedule(schedule);
     }
 
-    public ScheduleCommentPageGetResponse getScheduleComments(Schedule schedule, Pageable pageable) {
+    public ScheduleCommentPageGetResponse getScheduleComments(Optional<User> user, Schedule schedule,
+                                                              Pageable pageable) {
         Page<ScheduleComment> scheduleComments = scheduleCommentRepository.findAllByCommentedSchedule(schedule,
                 pageable);
-        List<ScheduleCommentGetResponse> scheduleGetResponses = scheduleComments.stream()
-                .map(ScheduleCommentGetResponse::of)
-                .toList();
+        List<ScheduleCommentGetResponse> scheduleGetResponses = new ArrayList<>();
+        for (ScheduleComment scheduleComment : scheduleComments.getContent()) {
+            boolean isUserCreated = false;
+            if (user.isPresent()) {
+                isUserCreated = scheduleComment.getCommentedUser() == user.get();
+            }
+            scheduleGetResponses.add(ScheduleCommentGetResponse.of(scheduleComment, isUserCreated));
+        }
 
         return ScheduleCommentPageGetResponse.builder()
                 .totalPages(scheduleComments.getTotalPages())

--- a/src/main/java/com/triprecord/triprecord/schedule/service/ScheduleCommentService.java
+++ b/src/main/java/com/triprecord/triprecord/schedule/service/ScheduleCommentService.java
@@ -35,7 +35,7 @@ public class ScheduleCommentService {
                 pageable);
         List<ScheduleCommentGetResponse> scheduleGetResponses = new ArrayList<>();
         for (ScheduleComment scheduleComment : scheduleComments.getContent()) {
-            boolean isUserCreated = isScheduleCommentCreated(user, scheduleComment);
+            boolean isUserCreated = isUserScheduleCommentCreated(user, scheduleComment);
             scheduleGetResponses.add(ScheduleCommentGetResponse.of(scheduleComment, isUserCreated));
         }
 
@@ -83,7 +83,7 @@ public class ScheduleCommentService {
                 new TripRecordException(ErrorCode.SCHEDULE_COMMENT_NOT_FOUND));
     }
 
-    private boolean isScheduleCommentCreated(Optional<User> user, ScheduleComment scheduleComment) {
+    private boolean isUserScheduleCommentCreated(Optional<User> user, ScheduleComment scheduleComment) {
         return user.filter(value -> value == scheduleComment.getCommentedUser()).isPresent();
     }
 


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- fix/#108 -> dev
- close #108

## Key Changes
<!-- 최대한 자세히 -->
### [일정 단건 조회, 일정 목록 조회, 일정 댓글 목록 조회] 
- 이 세가지 API 응답값에 현재 로그인한 유저가 해당 일정, 댓글을 생성한 유저인지 판별값을 나타내는 `isUserCreated` 값을 추가했습니다.
- 목록 조회에서는 해당 값이 굳이 필요하지 않지만, 단건 조회와 같은 Response DTO를 사용하기 때문에 함께 수정했습니다.

### 🔽 일정 단건 조회 호출 결과
<img width="863" alt="image" src="https://github.com/Trip-Record/Server/assets/109871579/a444794b-9ba8-40c9-b130-8f2caadef447">

### 🔽 일정 댓글 목록 조회 호출 결과
<img width="932" alt="image" src="https://github.com/Trip-Record/Server/assets/109871579/ee5f6136-f709-4d16-8899-c07fd98c930a">


## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->
X

## References
<!-- 참고한 자료-->
X