### PR TITLE
[FIX] 기록, 기록 댓글 응답 데이터에 생성 유저 판단 필드 추가

### DIFF
--- a/src/main/java/com/triprecord/triprecord/record/controller/RecordController.java
+++ b/src/main/java/com/triprecord/triprecord/record/controller/RecordController.java
@@ -67,9 +67,11 @@ public class RecordController {
     }
 
     @GetMapping("/{recordId}/comments")
-    public ResponseEntity<RecordCommentPage> getCommentPage(@PageableDefault(size = 5) Pageable pageable,
+    public ResponseEntity<RecordCommentPage> getCommentPage(Authentication authentication,
+                                                            @PageableDefault(size = 5) Pageable pageable,
                                                             @PathVariable Long recordId) {
-        return ResponseEntity.status(HttpStatus.OK).body(recordService.getRecordComments(recordId, pageable));
+        Optional<Long> userId = Optional.ofNullable((authentication == null) ? null : Long.parseLong(authentication.getName()));
+        return ResponseEntity.status(HttpStatus.OK).body(recordService.getRecordComments(userId, recordId, pageable));
     }
   
     @PostMapping("/{recordId}/comments")

--- a/src/main/java/com/triprecord/triprecord/record/controller/response/RecordResponse.java
+++ b/src/main/java/com/triprecord/triprecord/record/controller/response/RecordResponse.java
@@ -16,7 +16,8 @@ public record RecordResponse(
         LocalDate tripStartDate,
         LocalDate tripEndDate,
         List<RecordImageData> recordImages,
-        Boolean isUserLiked,
+        boolean isUserCreated,
+        boolean isUserLiked,
         Long likeCount,
         Long commentCount
 
@@ -24,7 +25,8 @@ public record RecordResponse(
     public static RecordResponse fromRecordData(Record record,
                                                 List<PlaceBasicData> recordPlaces,
                                                 List<RecordImageData> images,
-                                                Boolean userLiked,
+                                                boolean isUserCreated,
+                                                boolean isUserLiked,
                                                 Long likeCount,
                                                 Long commentCount){
         return new RecordResponse(
@@ -36,7 +38,8 @@ public record RecordResponse(
                 record.getTripStartDate(),
                 record.getTripEndDate(),
                 images,
-                userLiked,
+                isUserCreated,
+                isUserLiked,
                 likeCount,
                 commentCount
         );

--- a/src/main/java/com/triprecord/triprecord/record/dto/RecordCommentData.java
+++ b/src/main/java/com/triprecord/triprecord/record/dto/RecordCommentData.java
@@ -8,14 +8,16 @@ import com.triprecord.triprecord.user.dto.response.UserProfile;
 public record RecordCommentData(
         UserProfile userProfile,
         String commentContent,
-        String commentCreatedTime
+        String commentCreatedTime,
+        boolean isUserCreated
 ) {
 
-    public static RecordCommentData fromEntity(RecordComment recordComment) {
+    public static RecordCommentData fromEntity(RecordComment recordComment, boolean isUserCreated) {
         return new RecordCommentData(
                 UserProfile.of(recordComment.getCommentedUser()),
                 recordComment.getCommentContent(),
-                getDateTime(recordComment.getCreatedTime())
+                getDateTime(recordComment.getCreatedTime()),
+                isUserCreated
         );
     }
 }

--- a/src/main/java/com/triprecord/triprecord/record/service/RecordCommentService.java
+++ b/src/main/java/com/triprecord/triprecord/record/service/RecordCommentService.java
@@ -9,7 +9,9 @@ import com.triprecord.triprecord.record.entity.Record;
 import com.triprecord.triprecord.record.entity.RecordComment;
 import com.triprecord.triprecord.record.repository.RecordCommentRepository;
 import com.triprecord.triprecord.user.entity.User;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -30,9 +32,13 @@ public class RecordCommentService {
                 ()->new TripRecordException(ErrorCode.RECORD_COMMENT_NOT_FOUND));
     }
 
-    public RecordCommentPage getRecordComments(Record record, Pageable pageable) {
+    public RecordCommentPage getRecordComments(Optional<Long> userId, Record record, Pageable pageable) {
         Page<RecordComment> comments = recordCommentRepository.findAllByCommentedRecord(record, pageable);
-        List<RecordCommentData> commentData = comments.map(RecordCommentData::fromEntity).toList();
+        List<RecordCommentData> commentData = new ArrayList<>();
+        for(RecordComment comment : comments) {
+            boolean isUserCreated = userId.isPresent() && userId.get().equals(comment.getCommentedUser().getUserId());
+            commentData.add(RecordCommentData.fromEntity(comment, isUserCreated));
+        }
 
         return RecordCommentPage.builder()
                 .totalPages(comments.getTotalPages())

--- a/src/main/java/com/triprecord/triprecord/record/service/RecordService.java
+++ b/src/main/java/com/triprecord/triprecord/record/service/RecordService.java
@@ -81,17 +81,18 @@ public class RecordService {
         List<PlaceBasicData> recordPlaceData = recordPlaceService.getRecordPlaceBasicData(record);
         List<RecordImageData> recordImageData = recordImageService.findRecordImageData(record);
 
-        Boolean userRecordLiked = findUserRecordLiked(userId, record);
+        boolean isUserCreated = false; boolean isUserLiked = false;
+        if(userId.isPresent()) {
+            isUserCreated = Objects.equals(record.getCreatedUser().getUserId(), userId.get());
+            isUserLiked = recordLikeService.findUserLikedRecord(record, userService.getUserOrException(userId.get()));
+        }
+
         Long likeCount = recordLikeService.getRecordLikeCount(record);
         Long commentCount = recordCommentService.getRecordCommentCount(record);
 
-        return RecordResponse.fromRecordData(record, recordPlaceData, recordImageData, userRecordLiked, likeCount, commentCount);
+        return RecordResponse.fromRecordData(record, recordPlaceData, recordImageData, isUserCreated, isUserLiked, likeCount, commentCount);
     }
 
-    private Boolean findUserRecordLiked(Optional<Long> userId, Record record) {
-        if(userId.isPresent()) return recordLikeService.findUserLikedRecord(record, userService.getUserOrException(userId.get()));
-        return false;
-    }
 
     @Transactional
     public void deleteRecord(Long userId, Long recordId){

--- a/src/main/java/com/triprecord/triprecord/record/service/RecordService.java
+++ b/src/main/java/com/triprecord/triprecord/record/service/RecordService.java
@@ -118,10 +118,10 @@ public class RecordService {
     }
 
     @Transactional(readOnly = true)
-    public RecordCommentPage getRecordComments(Long recordId, Pageable pageable) {
+    public RecordCommentPage getRecordComments(Optional<Long> userId, Long recordId, Pageable pageable) {
         Record record = getRecordOrException(recordId);
 
-        return recordCommentService.getRecordComments(record, pageable);
+        return recordCommentService.getRecordComments(userId, record, pageable);
     }
   
     @Transactional


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- feat/#107 -> dev
- close #107 

## Key Changes
<!-- 최대한 자세히 -->
기록 응답 데이터와 기록 댓글 응답 데이터에
해당 기록, 댓글이 현재 로그인한 유저가 생성한 것인지 판단할 수 있는 isUserCreated 필드를 추가

- **기록 조회 성공시의 데이터**
![image](https://github.com/Trip-Record/Server/assets/105481797/332196bc-8393-4c46-8ac9-ceb31749937d)
isUserCreated 추가
- **기록 댓글 조회 성공시의 데이터**
![image](https://github.com/Trip-Record/Server/assets/105481797/3eb15b8c-807b-4bed-816e-70dfa146ab73)
isUserCreated 추가

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->


## References
<!-- 참고한 자료-->
