### PR TITLE
[FIX] 일정 댓글 목록 조회 API 응답값에 댓글 ID 추가

### DIFF
--- a/src/main/java/com/triprecord/triprecord/schedule/dto/response/ScheduleCommentGetResponse.java
+++ b/src/main/java/com/triprecord/triprecord/schedule/dto/response/ScheduleCommentGetResponse.java
@@ -7,6 +7,7 @@ import com.triprecord.triprecord.user.dto.response.UserProfile;
 
 public record ScheduleCommentGetResponse(
         UserProfile userProfile,
+        Long commentId,
         String commentContent,
         String commentCreatedTime,
         boolean isUserCreated
@@ -14,6 +15,7 @@ public record ScheduleCommentGetResponse(
     public static ScheduleCommentGetResponse of(ScheduleComment scheduleComment, boolean isUserCreated) {
         return new ScheduleCommentGetResponse(
                 UserProfile.of(scheduleComment.getCommentedUser()),
+                scheduleComment.getScheduleCommentId(),
                 scheduleComment.getScheduleCommentContent(),
                 getDateTime(scheduleComment.getCreatedTime()),
                 isUserCreated


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- fix/#112 -> dev
- close #112

## Key Changes
<!-- 최대한 자세히 -->
일정 댓글을 수정, 삭제하기 위해서는 일정의 ID가 필요하기 때문에, 일정 댓글 목록 조회 API 응답값에 댓글 ID를 추가했습니다.
### 테스트 결과
<img width="929" alt="image" src="https://github.com/Trip-Record/Server/assets/109871579/f1a3a3e5-b88d-416c-adfd-4f4a646468f5">

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->
X

## References
<!-- 참고한 자료-->
X