### PR TITLE
[FIX] 기록 댓글 응답 데이터에 댓글 id 값 추가

### DIFF
--- a/src/main/java/com/triprecord/triprecord/record/dto/RecordCommentData.java
+++ b/src/main/java/com/triprecord/triprecord/record/dto/RecordCommentData.java
@@ -7,6 +7,7 @@ import com.triprecord.triprecord.user.dto.response.UserProfile;
 
 public record RecordCommentData(
         UserProfile userProfile,
+        Long commentId,
         String commentContent,
         String commentCreatedTime,
         boolean isUserCreated
@@ -15,6 +16,7 @@ public record RecordCommentData(
     public static RecordCommentData fromEntity(RecordComment recordComment, boolean isUserCreated) {
         return new RecordCommentData(
                 UserProfile.of(recordComment.getCommentedUser()),
+                recordComment.getCommentId(),
                 recordComment.getCommentContent(),
                 getDateTime(recordComment.getCreatedTime()),
                 isUserCreated


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- feat/#111 -> dev
- close #111 

## Key Changes
<!-- 최대한 자세히 -->
### Comment 응답 DTO 에 CommentId 추가
- Comment 수정, 삭제 요청시에 필요한 데이터

![image](https://github.com/Trip-Record/Server/assets/105481797/edffa652-affa-48ff-81d1-269411b27668)


## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->

## References
<!-- 참고한 자료-->
