### PR TITLE
[FIX] 일정 목록 조회 API 세부 일정 날짜순 정렬되도록 로직 수정

### DIFF
--- a/src/main/java/com/triprecord/triprecord/schedule/service/ScheduleService.java
+++ b/src/main/java/com/triprecord/triprecord/schedule/service/ScheduleService.java
@@ -16,7 +16,6 @@ import com.triprecord.triprecord.schedule.entity.SchedulePlace;
 import com.triprecord.triprecord.schedule.repository.ScheduleRepository;
 import com.triprecord.triprecord.user.entity.User;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
@@ -86,11 +85,13 @@ public class ScheduleService {
                 userScheduleCreated = schedule.getCreatedUser() == user.get();
                 userScheduleLiked = scheduleLikeService.findUserLikedSchedule(schedule, user.get());
             }
+            List<ScheduleDetail> scheduleDetails = schedule.getScheduleDetails();
+            scheduleDetails.sort(Comparator.comparing(ScheduleDetail::getScheduleDetailDate));
             scheduleGetResponses.add(ScheduleGetResponse.of(
                     schedule.getCreatedUser(),
                     schedule,
                     schedule.getSchedulePlaces(),
-                    schedule.getScheduleDetails(),
+                    scheduleDetails,
                     userScheduleCreated,
                     userScheduleLiked,
                     scheduleLikeCount,
@@ -111,7 +112,7 @@ public class ScheduleService {
         List<SchedulePlace> schedulePlaces = schedule.getSchedulePlaces();
 
         List<ScheduleDetail> scheduleDetails = schedule.getScheduleDetails();
-        Collections.sort(scheduleDetails, Comparator.comparing(ScheduleDetail::getScheduleDetailDate));
+        scheduleDetails.sort(Comparator.comparing(ScheduleDetail::getScheduleDetailDate));
 
         boolean userScheduleCreated = false, userScheduleLiked = false;
         if (user.isPresent()) {


### PR DESCRIPTION
## Related Issue
<!-- feat/#issue -> dev와 같이 반영 브랜치를 표시 -->
<!-- closed #issue로 merge되면 issue가 자동으로 close되게 -->
- fix/#116 -> dev
- close #116

## Key Changes
<!-- 최대한 자세히 -->
일정 목록 조회 API 호출 시,
세부 일정 순서가 날짜순으로 나오지 않고 DB에 저장된 순으로 나오던 기존 방식에서 
세부 일정의 날짜 순으로(오름차순) 응답값에 나오게 하기 위해 정렬 로직을 추가했습니다!

### 기존
<img width="504" alt="image" src="https://github.com/Trip-Record/Server/assets/109871579/955d51b2-c926-4675-b074-24db14bbaf05">

### 정렬 로직 추가 후
<img width="469" alt="image" src="https://github.com/Trip-Record/Server/assets/109871579/e67bfff7-4675-4f29-8e30-6c4cd350232d">

## To Reviewers
<!-- 모호한 점, Key Changes에서 부족한 내용 -->
그리고, 기존 있던 Collections.sort() 코드도 list.sort() 로 변경해보았어요..!
비교적 최근에 나온 메서드라 좋을까 하여 ,,~

## References
<!-- 참고한 자료-->
X
